### PR TITLE
[codex] Fix Mistral NVFP4 B200 accuracy defaults

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1646,6 +1646,9 @@ def compute_mla_mscale_scaling(rope_scaling: dict, base_scaling: float) -> float
     Used by DeepSeek, BailingMoe, SarvamMLA and similar MLA models.
     Warns if 'factor' is missing from rope_scaling (common in v5 configs).
     """
+    if not rope_scaling.get("apply_yarn_scaling", True):
+        return base_scaling
+
     mscale_all_dim = rope_scaling.get("mscale_all_dim", False)
     if "factor" not in rope_scaling:
         logger.warning(

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -208,7 +208,6 @@ class FlashInferMLAAttnBackend(AttentionBackend):
             not skip_prefill
             and get_global_server_args().disaggregation_mode != "decode"
             and not get_global_server_args().disable_chunked_prefix_cache
-            and not get_global_server_args().flashinfer_mla_disable_ragged
         )
         self.page_size = model_runner.page_size
 
@@ -581,6 +580,8 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                     qall[:, :, : layer.v_head_dim],
                     qall[:, :, layer.v_head_dim :],
                 )
+            q = q.contiguous()
+            q_rope = q_rope.contiguous()
             o = q.new_empty(q.shape)
             o = prefill_wrapper_paged.run(
                 q,

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -9,6 +9,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.speculative.spec_info import SpecInput
 
+PAGED_MLA_MAX_PREFILL_TOKENS = 4096
+
 
 class HybridAttnBackend(AttentionBackend):
     """Support different backends for prefill and decode."""
@@ -18,18 +20,54 @@ class HybridAttnBackend(AttentionBackend):
         model_runner: ModelRunner,
         prefill_backend: AttentionBackend,
         decode_backend: AttentionBackend,
+        long_prefill_backend: Optional[AttentionBackend] = None,
     ):
         self.model_runner = model_runner
         self.prefill_backend = prefill_backend
         self.decode_backend = decode_backend
+        self.long_prefill_backend = long_prefill_backend
         self.data_type = model_runner.kv_cache_dtype
 
-    def _select_backend(self, forward_mode: ForwardMode) -> AttentionBackend:
+    @staticmethod
+    def _get_max_seq_len(seq_lens_cpu) -> int:
+        if seq_lens_cpu is None:
+            return 0
+        if hasattr(seq_lens_cpu, "numel"):
+            return int(seq_lens_cpu.max().item()) if seq_lens_cpu.numel() else 0
+        return max(seq_lens_cpu) if seq_lens_cpu else 0
+
+    @staticmethod
+    def _get_sum_extend_prefix_lens(extend_prefix_lens_cpu) -> int:
+        if extend_prefix_lens_cpu is None:
+            return 0
+        if hasattr(extend_prefix_lens_cpu, "numel"):
+            return int(extend_prefix_lens_cpu.sum().item())
+        return sum(extend_prefix_lens_cpu)
+
+    def _should_use_long_prefill_backend(self, forward_batch: ForwardBatch) -> bool:
+        if self.long_prefill_backend is None or forward_batch is None:
+            return False
+        if not forward_batch.forward_mode.is_extend_without_speculative():
+            return False
+
+        return (
+            self.model_runner.server_args.flashinfer_mla_disable_ragged
+            and self.model_runner.server_args.prefill_attention_backend == "flashinfer"
+            and self._get_sum_extend_prefix_lens(forward_batch.extend_prefix_lens_cpu)
+            == 0
+            and self._get_max_seq_len(forward_batch.seq_lens_cpu)
+            > PAGED_MLA_MAX_PREFILL_TOKENS
+        )
+
+    def _select_backend(
+        self, forward_mode: ForwardMode, forward_batch: Optional[ForwardBatch] = None
+    ) -> AttentionBackend:
         """
         Select the appropriate attention backend based on the forward mode.
 
         Args:
             forward_mode: The current forward mode indicating the operation type
+            forward_batch: Optional batch metadata for length-dependent prefill routing
 
         Returns:
             The selected attention backend (prefill or decode)
@@ -48,10 +86,12 @@ class HybridAttnBackend(AttentionBackend):
                 else self.prefill_backend
             )
         else:
+            if self._should_use_long_prefill_backend(forward_batch):
+                return self.long_prefill_backend
             return self.prefill_backend
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
-        backend = self._select_backend(forward_batch.forward_mode)
+        backend = self._select_backend(forward_batch.forward_mode, forward_batch)
         backend.init_forward_metadata(forward_batch)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
@@ -126,7 +166,7 @@ class HybridAttnBackend(AttentionBackend):
         **kwargs,
     ):
         """Forward method that supports both regular attention (q, k, v) and linear attention (mixed_qkv, a, b)."""
-        backend = self._select_backend(forward_batch.forward_mode)
+        backend = self._select_backend(forward_batch.forward_mode, forward_batch)
         if mixed_qkv is not None:
             return backend.forward(
                 layer=layer,
@@ -163,7 +203,7 @@ class HybridAttnBackend(AttentionBackend):
         save_kv_cache: bool = True,
         **kwargs,
     ):
-        backend = self._select_backend(forward_batch.forward_mode)
+        backend = self._select_backend(forward_batch.forward_mode, forward_batch)
         return backend.forward_extend(
             q, k, v, layer, forward_batch, save_kv_cache, **kwargs
         )
@@ -171,7 +211,7 @@ class HybridAttnBackend(AttentionBackend):
     def get_indexer_metadata(
         self, layer_id: int, forward_batch: ForwardBatch
     ) -> Optional[BaseIndexerMetadata]:
-        backend = self._select_backend(forward_batch.forward_mode)
+        backend = self._select_backend(forward_batch.forward_mode, forward_batch)
         return backend.get_indexer_metadata(layer_id, forward_batch)
 
     def forward(
@@ -185,7 +225,7 @@ class HybridAttnBackend(AttentionBackend):
         **kwargs,
     ):
         """Delegate forward to the appropriate backend based on forward mode."""
-        backend = self._select_backend(forward_batch.forward_mode)
+        backend = self._select_backend(forward_batch.forward_mode, forward_batch)
         return backend.forward(
             q=q,
             k=k,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2254,6 +2254,17 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 HybridAttnBackend,
             )
 
+            long_prefill_backend = None
+            if (
+                self.prefill_attention_backend_str == "flashinfer"
+                and self.server_args.flashinfer_mla_disable_ragged
+                and torch.cuda.get_device_capability(self.device)[0] >= 10
+            ):
+                long_prefill_backend = self._get_attention_backend_from_str(
+                    "fa4",
+                    init_new_workspace=init_new_workspace,
+                )
+
             attn_backend = HybridAttnBackend(
                 self,
                 decode_backend=self._get_attention_backend_from_str(
@@ -2264,12 +2275,18 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     self.prefill_attention_backend_str,
                     init_new_workspace=init_new_workspace,
                 ),
+                long_prefill_backend=long_prefill_backend,
             )
             logger.info(
                 f"Using hybrid attention backend for decode and prefill: "
                 f"decode_backend={self.decode_attention_backend_str}, "
                 f"prefill_backend={self.prefill_attention_backend_str}."
             )
+            if long_prefill_backend is not None:
+                logger.info(
+                    "Using fa4 as the long-context prefill fallback for "
+                    "flashinfer paged MLA."
+                )
             logger.warning(
                 "Warning: Attention backend specified by --attention-backend or default backend might be overridden."
                 "The feature of hybrid attention backend is experimental and unstable. Please raise an issue if you encounter any problem."

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -8,6 +8,7 @@ from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import use_intel_amx_backend
 
 MHA_ONE_SHOT_SUPPORTED_BACKENDS = ["fa3", "flashinfer", "flashmla"]
+PAGED_MLA_MAX_PREFILL_TOKENS = 4096
 
 
 class AttentionBackendRegistry:
@@ -61,6 +62,15 @@ def _get_sum_extend_prefix_lens(forward_batch):
     )
 
 
+def _get_max_seq_len(forward_batch):
+    seq_lens = forward_batch.seq_lens_cpu
+    if seq_lens is None:
+        return 0
+    if hasattr(seq_lens, "numel"):
+        return int(seq_lens.max().item()) if seq_lens.numel() else 0
+    return max(seq_lens) if seq_lens else 0
+
+
 def _support_mha_one_shot(attn, forward_batch, backend_name):
     attn_supported = backend_name in MHA_ONE_SHOT_SUPPORTED_BACKENDS
     sum_seq_lens = (
@@ -74,9 +84,27 @@ def _handle_attention_backend(attn, forward_batch, backend_name):
         return AttnForwardMethod.MLA
 
     sum_extend_prefix_lens = _get_sum_extend_prefix_lens(forward_batch)
-    disable_ragged = (
+    max_seq_len = _get_max_seq_len(forward_batch)
+    use_paged_mla_prefill = (
         backend_name in ["flashinfer", "flashmla"]
-    ) and attn.flashinfer_mla_disable_ragged
+        and attn.flashinfer_mla_disable_ragged
+        and sum_extend_prefix_lens == 0
+        and max_seq_len <= PAGED_MLA_MAX_PREFILL_TOKENS
+    )
+    use_chunked_mha_prefill = (
+        backend_name in ["flashinfer", "flashmla"]
+        and attn.flashinfer_mla_disable_ragged
+        and sum_extend_prefix_lens == 0
+        and max_seq_len > PAGED_MLA_MAX_PREFILL_TOKENS
+    )
+
+    if (
+        use_chunked_mha_prefill
+        and forward_batch.forward_mode.is_extend_without_speculative()
+    ):
+        return AttnForwardMethod.MHA_CHUNKED_KV
+
+    disable_ragged = use_paged_mla_prefill
 
     if (
         not disable_ragged

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -41,6 +41,8 @@ def _resolve_attn_backend(forward_batch: ForwardBatch):
     backend = forward_batch.attn_backend
     if isinstance(backend, TboAttnBackend):
         backend = backend.primary
+    if hasattr(backend, "_select_backend"):
+        backend = backend._select_backend(forward_batch.forward_mode, forward_batch)
     return backend
 
 
@@ -334,8 +336,9 @@ class DeepseekMHAForwardMixin:
         # Only initialize the info once
         if has_extend_prefix and forward_batch.num_prefix_chunks is None:
             forward_batch.prepare_chunked_prefix_cache_info(q.device)
-            if hasattr(forward_batch.attn_backend, "init_mha_chunk_metadata"):
-                forward_batch.attn_backend.init_mha_chunk_metadata(forward_batch)
+            backend = _resolve_attn_backend(forward_batch)
+            if hasattr(backend, "init_mha_chunk_metadata"):
+                backend.init_mha_chunk_metadata(forward_batch)
 
         forward_batch.mha_return_lse = has_extend_prefix
         # Do mha for extended part without prefix
@@ -380,8 +383,9 @@ class DeepseekMHAForwardMixin:
         # Only initialize the info once
         if has_extend_prefix and forward_batch.num_prefix_chunks is None:
             forward_batch.num_prefix_chunks = 0
-            if hasattr(forward_batch.attn_backend, "init_mha_chunk_metadata"):
-                forward_batch.attn_backend.init_mha_chunk_metadata(forward_batch)
+            backend = _resolve_attn_backend(forward_batch)
+            if hasattr(backend, "init_mha_chunk_metadata"):
+                backend.init_mha_chunk_metadata(forward_batch)
         forward_batch.mha_return_lse = False
         # Do mha for extended part without prefix
         forward_batch.set_attn_attend_prefix_cache(False)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1754,11 +1754,11 @@ class ServerArgs:
         ):
             return False
 
-        self.prefill_attention_backend = "flashinfer"
+        self.prefill_attention_backend = "fa4"
         self.decode_attention_backend = "trtllm_mla"
         self.flashinfer_mla_disable_ragged = True
         logger.info(
-            "Use flashinfer prefill and trtllm_mla decode attention backends on sm100 "
+            "Use fa4 prefill and trtllm_mla decode attention backends on sm100 "
             f"for {model_arch} compressed-tensors NVFP4"
         )
         logger.info(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1745,8 +1745,13 @@ class ServerArgs:
     def _maybe_set_mistral_nvfp4_sm100_attention_backend(
         self, model_arch: str, is_compressed_tensors_nvfp4: bool
     ) -> bool:
+        is_mistral_mla_model = (
+            model_arch in MISTRAL_LARGE3_MLA_MODEL_ARCHS
+            or self.load_format == "mistral"
+            or (self.load_format == "auto" and self._is_mistral_native_format())
+        )
         if (
-            model_arch not in MISTRAL_LARGE3_MLA_MODEL_ARCHS
+            not is_mistral_mla_model
             or not is_compressed_tensors_nvfp4
             or not is_sm100_supported()
             or not self.use_mla_backend()
@@ -1754,16 +1759,16 @@ class ServerArgs:
         ):
             return False
 
-        self.prefill_attention_backend = "fa4"
+        self.prefill_attention_backend = "flashinfer"
         self.decode_attention_backend = "trtllm_mla"
         self.flashinfer_mla_disable_ragged = True
         logger.info(
-            "Use fa4 prefill and trtllm_mla decode attention backends on sm100 "
+            "Use flashinfer prefill and trtllm_mla decode attention backends on sm100 "
             f"for {model_arch} compressed-tensors NVFP4"
         )
         logger.info(
-            "Disable FlashInfer MLA ragged prefill on sm100 "
-            f"for {model_arch} compressed-tensors NVFP4"
+            "Use FlashInfer MLA paged prefill for short uncached prompts and MHA "
+            f"for long or cached prefixes on sm100 for {model_arch} compressed-tensors NVFP4"
         )
         return True
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -253,6 +253,7 @@ def _is_compressed_tensors_nvfp4_quant(
         return False
     return quant_cfg.get("format") == "nvfp4-pack-quantized"
 
+
 RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru", "priority"]
 
 RL_ON_POLICY_TARGET_CHOICES = ["fsdp"]
@@ -1925,9 +1926,12 @@ class ServerArgs:
                     logger.info("Piecewise CUDA graph is enabled, use MLA for prefill.")
 
                 if is_sm100_supported():
-                    if not self._maybe_set_mistral_nvfp4_sm100_attention_backend(
-                        model_arch, is_compressed_tensors_nvfp4
-                    ) and self.is_attention_backend_not_set():
+                    if (
+                        not self._maybe_set_mistral_nvfp4_sm100_attention_backend(
+                            model_arch, is_compressed_tensors_nvfp4
+                        )
+                        and self.is_attention_backend_not_set()
+                    ):
                         self.attention_backend = "trtllm_mla"
                         logger.info(
                             f"Use trtllm_mla as attention backend on sm100 for {model_arch}"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -209,6 +209,11 @@ MOE_RUNNER_BACKEND_CHOICES = [
     "marlin",
 ]
 
+MISTRAL_LARGE3_MLA_MODEL_ARCHS = {
+    "MistralLarge3ForCausalLM",
+    "PixtralForConditionalGeneration",
+}
+
 MOE_A2A_BACKEND_CHOICES = [
     "none",
     "deepep",
@@ -239,6 +244,14 @@ FP4_GEMM_RUNNER_BACKEND_CHOICES = [
     "flashinfer_cutlass",
     "flashinfer_trtllm",
 ]
+
+
+def _is_compressed_tensors_nvfp4_quant(
+    quant_method: Optional[str], quant_cfg: Optional[Dict[str, Any]]
+) -> bool:
+    if quant_method != "compressed-tensors" or not isinstance(quant_cfg, dict):
+        return False
+    return quant_cfg.get("format") == "nvfp4-pack-quantized"
 
 RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru", "priority"]
 
@@ -1729,6 +1742,31 @@ class ServerArgs:
             f"Set DSA backends for {self.kv_cache_dtype} KV Cache: prefill={self.dsa_prefill_backend}, decode={self.dsa_decode_backend}."
         )
 
+    def _maybe_set_mistral_nvfp4_sm100_attention_backend(
+        self, model_arch: str, is_compressed_tensors_nvfp4: bool
+    ) -> bool:
+        if (
+            model_arch not in MISTRAL_LARGE3_MLA_MODEL_ARCHS
+            or not is_compressed_tensors_nvfp4
+            or not is_sm100_supported()
+            or not self.use_mla_backend()
+            or not self.is_attention_backend_not_set()
+        ):
+            return False
+
+        self.prefill_attention_backend = "flashinfer"
+        self.decode_attention_backend = "trtllm_mla"
+        self.flashinfer_mla_disable_ragged = True
+        logger.info(
+            "Use flashinfer prefill and trtllm_mla decode attention backends on sm100 "
+            f"for {model_arch} compressed-tensors NVFP4"
+        )
+        logger.info(
+            "Disable FlashInfer MLA ragged prefill on sm100 "
+            f"for {model_arch} compressed-tensors NVFP4"
+        )
+        return True
+
     def _handle_model_specific_adjustments(self):
         from sglang.srt.configs.model_config import (
             get_mimo_v2_fused_qkv_expected_tp_size,
@@ -1772,7 +1810,18 @@ class ServerArgs:
             "PixtralForConditionalGeneration",
             "GlmMoeDsaForCausalLM",
         ]:
-            # Set attention backend for DeepSeek
+            quant_method = get_quantization_config(hf_config)
+            quant_cfg = getattr(hf_config, "quantization_config", None) or {}
+            is_compressed_tensors_nvfp4 = _is_compressed_tensors_nvfp4_quant(
+                quant_method, quant_cfg
+            )
+            is_mistral_mla_compressed_tensors_nvfp4 = (
+                model_arch in MISTRAL_LARGE3_MLA_MODEL_ARCHS
+                and is_compressed_tensors_nvfp4
+                and self.use_mla_backend()
+            )
+
+            # Set attention backend for MLA model families.
             if is_deepseek_dsa(hf_config):  # DeepSeek 3.2/GLM 5
                 if model_arch == "GlmMoeDsaForCausalLM" and is_blackwell_supported():
                     envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.set(0)
@@ -1871,20 +1920,16 @@ class ServerArgs:
                     logger.info("Piecewise CUDA graph is enabled, use MLA for prefill.")
 
                 if is_sm100_supported():
-                    if (
-                        self.attention_backend is None
-                        and self.prefill_attention_backend is None
-                        and self.decode_attention_backend is None
-                    ):
+                    if not self._maybe_set_mistral_nvfp4_sm100_attention_backend(
+                        model_arch, is_compressed_tensors_nvfp4
+                    ) and self.is_attention_backend_not_set():
                         self.attention_backend = "trtllm_mla"
                         logger.info(
-                            "Use trtllm_mla as attention backend on sm100 for DeepseekV3ForCausalLM"
+                            f"Use trtllm_mla as attention backend on sm100 for {model_arch}"
                         )
 
-            # Set moe backend for DeepSeek
+            # Set MoE backend for MLA model families.
             if is_sm100_supported():
-                quant_method = get_quantization_config(hf_config)
-                quant_cfg = getattr(hf_config, "quantization_config", None) or {}
                 config_groups = quant_cfg.get("config_groups", {})
                 group0 = config_groups.get("group_0", {})
                 weights_cfg = group0.get("weights", {})
@@ -1928,6 +1973,7 @@ class ServerArgs:
                         self.quantization
                         in ["fp8", "modelopt_fp8", "modelopt_fp4", "modelopt_mixed"]
                         or is_kimi_k2_k25_thinking_int4
+                        or is_mistral_mla_compressed_tensors_nvfp4
                         or self.quantization is None
                     )
                 ):
@@ -1936,9 +1982,14 @@ class ServerArgs:
                         logger.info(
                             "Use flashinfer_trtllm as MoE runner backend on Blackwell for Kimi K2 / K2.5 thinking int4"
                         )
+                    elif is_mistral_mla_compressed_tensors_nvfp4:
+                        logger.info(
+                            "Use flashinfer_trtllm as MoE runner backend on sm100 "
+                            f"for {model_arch} compressed-tensors NVFP4"
+                        )
                     else:
                         logger.info(
-                            "Use flashinfer_trtllm as MoE runner backend on sm100 for DeepseekV3ForCausalLM"
+                            f"Use flashinfer_trtllm as MoE runner backend on sm100 for {model_arch}"
                         )
             elif is_hip():
                 if not self.enable_dp_attention and self.nnodes == 1:

--- a/python/sglang/srt/utils/hf_transformers/tokenizer.py
+++ b/python/sglang/srt/utils/hf_transformers/tokenizer.py
@@ -38,6 +38,7 @@ from .common import (
 )
 from .mistral_utils import (
     _MISTRAL_TOKENIZER_REDIRECTS,
+    is_mistral_model,
     patch_mistral_common_tokenizer,
     retry_without_mistral_common_kwargs,
 )
@@ -47,6 +48,22 @@ _FAST_LLAMA_TOKENIZER = "hf-internal-testing/llama-tokenizer"
 
 # Class name used by transformers v5 when no tokenizer mapping exists for a model_type.
 _TOKENIZERS_BACKEND = "TokenizersBackend"
+
+# Native Mistral repositories carry either tekken.json or tokenizer.model.v*.
+# vLLM switches those repos to Mistral tokenizer mode, whose text encoding adds
+# BOS by default. HF's generic TokenizersBackend does not, so SGLang needs a
+# narrow compatibility fix when AutoTokenizer cannot resolve a model-specific
+# tokenizer class.
+_MISTRAL_NATIVE_TOKENIZER_FILES = (
+    "tekken.json",
+    "tokenizer.model.v1",
+    "tokenizer.model.v2",
+    "tokenizer.model.v3",
+    "tokenizer.model.v4",
+    "tokenizer.model.v5",
+    "tokenizer.model.v6",
+    "tokenizer.model.v7",
+)
 
 
 def _load_tokenizer_by_declared_class(tokenizer_name, *args, **kwargs):
@@ -401,6 +418,58 @@ def _fix_v5_add_bos_eos_token(tokenizer, model_name_or_path, revision=None):
         tokenizer.update_post_processor()
 
 
+def _has_mistral_native_tokenizer_files(model_name_or_path, revision=None):
+    model_path = Path(model_name_or_path)
+    if model_path.is_dir() and list(model_path.glob("tokenizer.model.v*")):
+        return True
+
+    for filename in _MISTRAL_NATIVE_TOKENIZER_FILES:
+        try:
+            _resolve_local_or_cached_file(model_name_or_path, filename, revision)
+            return True
+        except FileNotFoundError:
+            continue
+
+    return False
+
+
+def _fix_mistral_native_tokenizers_backend_bos(
+    tokenizer, model_name_or_path, revision=None
+):
+    """Make generic HF TokenizersBackend match native Mistral text encoding.
+
+    Native Mistral tokenizers add BOS for plain text prompts.  When transformers
+    falls back to the generic TokenizersBackend for those repos, the loaded
+    tokenizer has ``add_bos_token=False`` and SGLang silently serves prompts one
+    token off from vLLM's ``tokenizer_mode=mistral`` path.  This is visible on
+    accuracy evals such as GSM8K/MMLU.
+    """
+    if type(tokenizer).__name__ != _TOKENIZERS_BACKEND:
+        return
+    if not is_mistral_model(model_name_or_path):
+        return
+    if getattr(tokenizer, "bos_token_id", None) is None:
+        return
+    if getattr(tokenizer, "add_bos_token", None) is True:
+        return
+    if not _has_mistral_native_tokenizer_files(model_name_or_path, revision):
+        return
+
+    logger.info(
+        "Enabling add_bos_token=True for native Mistral tokenizer %s "
+        "loaded as TokenizersBackend",
+        model_name_or_path,
+    )
+    setattr(tokenizer, "_add_bos_token", True)
+    try:
+        tokenizer.add_bos_token = True
+    except AttributeError:
+        pass
+
+    if hasattr(tokenizer, "update_post_processor"):
+        tokenizer.update_post_processor()
+
+
 def _fix_special_tokens_pattern(tokenizer):
     """Fix https://github.com/huggingface/transformers/pull/42563 which defaults
     special_tokens_pattern to "cls_sep", inserting None into token IDs when
@@ -417,6 +486,7 @@ def _apply_post_load_fixes(tokenizer, tokenizer_name, revision):
     """Apply all post-load patches and return the final tokenizer."""
     _fix_v5_tokenizer_components(tokenizer, tokenizer_name, revision)
     _fix_v5_add_bos_eos_token(tokenizer, tokenizer_name, revision)
+    _fix_mistral_native_tokenizers_backend_bos(tokenizer, tokenizer_name, revision)
 
     if not isinstance(tokenizer, PreTrainedTokenizerFast):
         warnings.warn(

--- a/test/registered/unit/configs/test_model_config_scaling.py
+++ b/test/registered/unit/configs/test_model_config_scaling.py
@@ -1,0 +1,38 @@
+import math
+import unittest
+
+from sglang.srt.configs.model_config import compute_mla_mscale_scaling
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestMlaMscaleScaling(unittest.TestCase):
+    def test_respects_disabled_yarn_scaling(self):
+        base_scaling = 1 / math.sqrt(128)
+        rope_scaling = {
+            "rope_type": "deepseek_yarn",
+            "factor": 128,
+            "mscale_all_dim": 1,
+            "apply_yarn_scaling": False,
+        }
+
+        self.assertEqual(
+            compute_mla_mscale_scaling(rope_scaling, base_scaling), base_scaling
+        )
+
+    def test_applies_yarn_scaling_by_default(self):
+        base_scaling = 1 / math.sqrt(128)
+        rope_scaling = {
+            "rope_type": "deepseek_yarn",
+            "factor": 128,
+            "mscale_all_dim": 1,
+        }
+
+        self.assertGreater(
+            compute_mla_mscale_scaling(rope_scaling, base_scaling), base_scaling
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_mla_attention_backend_handler.py
+++ b/test/registered/unit/models/test_mla_attention_backend_handler.py
@@ -9,6 +9,9 @@ from sglang.srt.models.deepseek_common.attention_backend_handler import (
 from sglang.srt.models.deepseek_common.attention_forward_methods.forward_methods import (
     AttnForwardMethod,
 )
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
 class _FakeForwardMode:
@@ -35,7 +38,9 @@ class _FakeForwardBatch:
     def __init__(self, seq_lens_cpu, use_tensor=False, max_chunk_capacity=4096):
         self.forward_mode = _FakeForwardMode()
         self.seq_lens_cpu = (
-            torch.tensor(seq_lens_cpu, dtype=torch.int32) if use_tensor else seq_lens_cpu
+            torch.tensor(seq_lens_cpu, dtype=torch.int32)
+            if use_tensor
+            else seq_lens_cpu
         )
         self.extend_prefix_lens_cpu = [0] * len(seq_lens_cpu)
         self.max_chunk_capacity = max_chunk_capacity

--- a/test/registered/unit/models/test_mla_attention_backend_handler.py
+++ b/test/registered/unit/models/test_mla_attention_backend_handler.py
@@ -1,0 +1,100 @@
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.hybrid_attn_backend import HybridAttnBackend
+from sglang.srt.models.deepseek_common.attention_backend_handler import (
+    _handle_attention_backend,
+)
+from sglang.srt.models.deepseek_common.attention_forward_methods.forward_methods import (
+    AttnForwardMethod,
+)
+
+
+class _FakeForwardMode:
+    def is_decode_or_idle(self):
+        return False
+
+    def is_target_verify(self):
+        return False
+
+    def is_draft_extend(self):
+        return False
+
+    def is_extend_without_speculative(self):
+        return True
+
+
+class _FakeAttn:
+    flashinfer_mla_disable_ragged = True
+    chunked_prefix_cache_threshold = 0
+    disable_chunked_prefix_cache = False
+
+
+class _FakeForwardBatch:
+    def __init__(self, seq_lens_cpu, use_tensor=False, max_chunk_capacity=4096):
+        self.forward_mode = _FakeForwardMode()
+        self.seq_lens_cpu = (
+            torch.tensor(seq_lens_cpu, dtype=torch.int32) if use_tensor else seq_lens_cpu
+        )
+        self.extend_prefix_lens_cpu = [0] * len(seq_lens_cpu)
+        self.max_chunk_capacity = max_chunk_capacity
+
+    def get_max_chunk_capacity(self):
+        return self.max_chunk_capacity
+
+
+class _FakeServerArgs:
+    flashinfer_mla_disable_ragged = True
+    prefill_attention_backend = "flashinfer"
+    speculative_attention_mode = "prefill"
+
+
+class _FakeModelRunner:
+    kv_cache_dtype = torch.bfloat16
+    server_args = _FakeServerArgs()
+
+
+class TestMlaAttentionBackendHandler(unittest.TestCase):
+    def test_flashinfer_short_uncached_prefill_uses_paged_mla(self):
+        forward_batch = _FakeForwardBatch([1000])
+
+        method = _handle_attention_backend(_FakeAttn(), forward_batch, "flashinfer")
+
+        self.assertEqual(method, AttnForwardMethod.MLA)
+
+    def test_flashinfer_long_uncached_prefill_uses_mha(self):
+        forward_batch = _FakeForwardBatch(
+            [8000], use_tensor=True, max_chunk_capacity=20000
+        )
+
+        method = _handle_attention_backend(_FakeAttn(), forward_batch, "flashinfer")
+
+        self.assertEqual(method, AttnForwardMethod.MHA_CHUNKED_KV)
+
+    def test_hybrid_routes_long_uncached_prefill_to_fallback_backend(self):
+        prefill_backend = object()
+        decode_backend = object()
+        long_prefill_backend = object()
+        hybrid_backend = HybridAttnBackend(
+            _FakeModelRunner(),
+            prefill_backend=prefill_backend,
+            decode_backend=decode_backend,
+            long_prefill_backend=long_prefill_backend,
+        )
+
+        short_batch = _FakeForwardBatch([1000])
+        long_batch = _FakeForwardBatch([8000], use_tensor=True)
+
+        self.assertIs(
+            hybrid_backend._select_backend(short_batch.forward_mode, short_batch),
+            prefill_backend,
+        )
+        self.assertIs(
+            hybrid_backend._select_backend(long_batch.forward_mode, long_batch),
+            long_prefill_backend,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -4,7 +4,12 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
-from sglang.srt.server_args import PortArgs, ServerArgs, prepare_server_args
+from sglang.srt.server_args import (
+    PortArgs,
+    ServerArgs,
+    _is_compressed_tensors_nvfp4_quant,
+    prepare_server_args,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
@@ -33,6 +38,84 @@ class TestPrepareServerArgs(CustomTestCase):
             json.loads(server_args.json_model_override_args),
             {"rope_scaling": {"factor": 2.0, "rope_type": "linear"}},
         )
+
+
+class TestMistralNvfp4BackendDefaults(unittest.TestCase):
+    def _make_server_args(
+        self,
+        attention_backend=None,
+        prefill_attention_backend=None,
+        decode_attention_backend=None,
+    ):
+        server_args = ServerArgs.__new__(ServerArgs)
+        server_args.attention_backend = attention_backend
+        server_args.prefill_attention_backend = prefill_attention_backend
+        server_args.decode_attention_backend = decode_attention_backend
+        return server_args
+
+    def test_detects_compressed_tensors_nvfp4_format(self):
+        self.assertTrue(
+            _is_compressed_tensors_nvfp4_quant(
+                "compressed-tensors", {"format": "nvfp4-pack-quantized"}
+            )
+        )
+        self.assertFalse(
+            _is_compressed_tensors_nvfp4_quant(
+                "compressed-tensors", {"format": "pack-quantized"}
+            )
+        )
+        self.assertFalse(
+            _is_compressed_tensors_nvfp4_quant(
+                "modelopt_fp4", {"format": "nvfp4-pack-quantized"}
+            )
+        )
+
+    @patch("sglang.srt.server_args.is_sm100_supported", return_value=True)
+    @patch.object(ServerArgs, "use_mla_backend", return_value=True)
+    def test_sets_flashinfer_prefill_and_trtllm_mla_decode_for_unset_pixtral_nvfp4(
+        self, _mock_use_mla, _mock_sm100
+    ):
+        server_args = self._make_server_args()
+
+        changed = server_args._maybe_set_mistral_nvfp4_sm100_attention_backend(
+            "PixtralForConditionalGeneration", True
+        )
+
+        self.assertTrue(changed)
+        self.assertIsNone(server_args.attention_backend)
+        self.assertEqual(server_args.prefill_attention_backend, "flashinfer")
+        self.assertEqual(server_args.decode_attention_backend, "trtllm_mla")
+        self.assertTrue(server_args.flashinfer_mla_disable_ragged)
+
+    @patch("sglang.srt.server_args.is_sm100_supported", return_value=True)
+    @patch.object(ServerArgs, "use_mla_backend", return_value=True)
+    def test_preserves_explicit_attention_backend(
+        self, _mock_use_mla, _mock_sm100
+    ):
+        server_args = self._make_server_args(attention_backend="flashinfer")
+
+        changed = server_args._maybe_set_mistral_nvfp4_sm100_attention_backend(
+            "PixtralForConditionalGeneration", True
+        )
+
+        self.assertFalse(changed)
+        self.assertEqual(server_args.attention_backend, "flashinfer")
+        self.assertIsNone(server_args.prefill_attention_backend)
+        self.assertIsNone(server_args.decode_attention_backend)
+
+    @patch("sglang.srt.server_args.is_sm100_supported", return_value=True)
+    @patch.object(ServerArgs, "use_mla_backend", return_value=False)
+    def test_skips_non_mla_pixtral_model(self, _mock_use_mla, _mock_sm100):
+        server_args = self._make_server_args()
+
+        changed = server_args._maybe_set_mistral_nvfp4_sm100_attention_backend(
+            "PixtralForConditionalGeneration", True
+        )
+
+        self.assertFalse(changed)
+        self.assertIsNone(server_args.attention_backend)
+        self.assertIsNone(server_args.prefill_attention_backend)
+        self.assertIsNone(server_args.decode_attention_backend)
 
 
 class TestLoadBalanceMethod(unittest.TestCase):

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -108,9 +108,7 @@ class TestMistralNvfp4BackendDefaults(unittest.TestCase):
 
     @patch("sglang.srt.server_args.is_sm100_supported", return_value=True)
     @patch.object(ServerArgs, "use_mla_backend", return_value=True)
-    def test_preserves_explicit_attention_backend(
-        self, _mock_use_mla, _mock_sm100
-    ):
+    def test_preserves_explicit_attention_backend(self, _mock_use_mla, _mock_sm100):
         server_args = self._make_server_args(attention_backend="flashinfer")
 
         changed = server_args._maybe_set_mistral_nvfp4_sm100_attention_backend(

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -46,11 +46,13 @@ class TestMistralNvfp4BackendDefaults(unittest.TestCase):
         attention_backend=None,
         prefill_attention_backend=None,
         decode_attention_backend=None,
+        load_format="auto",
     ):
         server_args = ServerArgs.__new__(ServerArgs)
         server_args.attention_backend = attention_backend
         server_args.prefill_attention_backend = prefill_attention_backend
         server_args.decode_attention_backend = decode_attention_backend
+        server_args.load_format = load_format
         return server_args
 
     def test_detects_compressed_tensors_nvfp4_format(self):
@@ -72,7 +74,7 @@ class TestMistralNvfp4BackendDefaults(unittest.TestCase):
 
     @patch("sglang.srt.server_args.is_sm100_supported", return_value=True)
     @patch.object(ServerArgs, "use_mla_backend", return_value=True)
-    def test_sets_fa4_prefill_and_trtllm_mla_decode_for_unset_pixtral_nvfp4(
+    def test_sets_flashinfer_prefill_and_trtllm_mla_decode_for_unset_pixtral_nvfp4(
         self, _mock_use_mla, _mock_sm100
     ):
         server_args = self._make_server_args()
@@ -83,7 +85,24 @@ class TestMistralNvfp4BackendDefaults(unittest.TestCase):
 
         self.assertTrue(changed)
         self.assertIsNone(server_args.attention_backend)
-        self.assertEqual(server_args.prefill_attention_backend, "fa4")
+        self.assertEqual(server_args.prefill_attention_backend, "flashinfer")
+        self.assertEqual(server_args.decode_attention_backend, "trtllm_mla")
+        self.assertTrue(server_args.flashinfer_mla_disable_ragged)
+
+    @patch("sglang.srt.server_args.is_sm100_supported", return_value=True)
+    @patch.object(ServerArgs, "_is_mistral_native_format", return_value=True)
+    @patch.object(ServerArgs, "use_mla_backend", return_value=True)
+    def test_sets_flashinfer_prefill_for_native_mistral_arch_alias(
+        self, _mock_use_mla, _mock_mistral_native, _mock_sm100
+    ):
+        server_args = self._make_server_args()
+
+        changed = server_args._maybe_set_mistral_nvfp4_sm100_attention_backend(
+            "DeepseekV3ForCausalLM", True
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(server_args.prefill_attention_backend, "flashinfer")
         self.assertEqual(server_args.decode_attention_backend, "trtllm_mla")
         self.assertTrue(server_args.flashinfer_mla_disable_ragged)
 

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -72,7 +72,7 @@ class TestMistralNvfp4BackendDefaults(unittest.TestCase):
 
     @patch("sglang.srt.server_args.is_sm100_supported", return_value=True)
     @patch.object(ServerArgs, "use_mla_backend", return_value=True)
-    def test_sets_flashinfer_prefill_and_trtllm_mla_decode_for_unset_pixtral_nvfp4(
+    def test_sets_fa4_prefill_and_trtllm_mla_decode_for_unset_pixtral_nvfp4(
         self, _mock_use_mla, _mock_sm100
     ):
         server_args = self._make_server_args()
@@ -83,7 +83,7 @@ class TestMistralNvfp4BackendDefaults(unittest.TestCase):
 
         self.assertTrue(changed)
         self.assertIsNone(server_args.attention_backend)
-        self.assertEqual(server_args.prefill_attention_backend, "flashinfer")
+        self.assertEqual(server_args.prefill_attention_backend, "fa4")
         self.assertEqual(server_args.decode_attention_backend, "trtllm_mla")
         self.assertTrue(server_args.flashinfer_mla_disable_ragged)
 

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -7,6 +7,7 @@ context length, GGUF detection, etc.) that don't require actual model files.
 import tempfile
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from transformers import PretrainedConfig
 
@@ -20,7 +21,10 @@ from sglang.srt.utils.hf_transformers.common import (
     get_hf_text_config,
     get_rope_config,
 )
-from sglang.srt.utils.hf_transformers.tokenizer import _fix_special_tokens_pattern
+from sglang.srt.utils.hf_transformers.tokenizer import (
+    _fix_mistral_native_tokenizers_backend_bos,
+    _fix_special_tokens_pattern,
+)
 from sglang.srt.utils.hf_transformers_patches import normalize_rope_scaling_compat
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -383,6 +387,91 @@ class TestGetHfTextConfig(unittest.TestCase):
         get_hf_text_config(cfg)
         self.assertIn("type", cfg.rope_scaling)
         self.assertEqual(cfg.rope_scaling["type"], "llama3")
+
+
+# ---------------------------------------------------------------------------
+# Mistral native tokenizer BOS fix
+# ---------------------------------------------------------------------------
+
+
+class TokenizersBackend:
+    def __init__(self, add_bos_token=False, bos_token_id=1):
+        self.add_bos_token = add_bos_token
+        self._add_bos_token = add_bos_token
+        self.bos_token_id = bos_token_id
+        self.update_post_processor_calls = 0
+
+    def update_post_processor(self):
+        self.update_post_processor_calls += 1
+
+
+class TestMistralNativeTokenizersBackendBos(unittest.TestCase):
+    def test_enables_bos_for_mistral_native_tokenizers_backend(self):
+        tok = TokenizersBackend(add_bos_token=False)
+
+        def resolve_file(_model_name, filename, _revision=None):
+            if filename == "tekken.json":
+                return "/tmp/tekken.json"
+            raise FileNotFoundError
+
+        with patch(
+            "sglang.srt.utils.hf_transformers.tokenizer._resolve_local_or_cached_file",
+            side_effect=resolve_file,
+        ):
+            _fix_mistral_native_tokenizers_backend_bos(
+                tok, "mistralai/Mistral-Small-4-119B-2603-NVFP4"
+            )
+
+        self.assertTrue(tok.add_bos_token)
+        self.assertTrue(tok._add_bos_token)
+        self.assertEqual(tok.update_post_processor_calls, 1)
+
+    def test_no_change_without_native_tokenizer_files(self):
+        tok = TokenizersBackend(add_bos_token=False)
+
+        with patch(
+            "sglang.srt.utils.hf_transformers.tokenizer._resolve_local_or_cached_file",
+            side_effect=FileNotFoundError,
+        ):
+            _fix_mistral_native_tokenizers_backend_bos(
+                tok, "mistralai/Mistral-Small-4-119B-2603-NVFP4"
+            )
+
+        self.assertFalse(tok.add_bos_token)
+        self.assertFalse(tok._add_bos_token)
+        self.assertEqual(tok.update_post_processor_calls, 0)
+
+    def test_no_change_for_non_mistral_model(self):
+        tok = TokenizersBackend(add_bos_token=False)
+
+        with patch(
+            "sglang.srt.utils.hf_transformers.tokenizer._resolve_local_or_cached_file"
+        ) as resolve_file:
+            _fix_mistral_native_tokenizers_backend_bos(tok, "Qwen/Qwen3-8B")
+
+        resolve_file.assert_not_called()
+        self.assertFalse(tok.add_bos_token)
+        self.assertFalse(tok._add_bos_token)
+        self.assertEqual(tok.update_post_processor_calls, 0)
+
+    def test_no_change_for_specific_tokenizer_class(self):
+        tok = SimpleNamespace(
+            add_bos_token=False,
+            _add_bos_token=False,
+            bos_token_id=1,
+            update_post_processor=lambda: None,
+        )
+
+        with patch(
+            "sglang.srt.utils.hf_transformers.tokenizer._resolve_local_or_cached_file"
+        ) as resolve_file:
+            _fix_mistral_native_tokenizers_backend_bos(
+                tok, "mistralai/Mistral-Small-4-119B-2603-NVFP4"
+            )
+
+        resolve_file.assert_not_called()
+        self.assertFalse(tok.add_bos_token)
+        self.assertFalse(tok._add_bos_token)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR fixes Mistral/Pixtral compressed-tensors NVFP4 MLA on SM100/B200:

- respect native Mistral YARN `apply_scale=false` when deriving `model_config.scaling`, fixing the large GSM8K/MMLU accuracy drop on FlashInfer paged MLA
- use FlashInfer prefill + TRT-LLM MLA decode by default for Mistral/Pixtral NVFP4 MLA on SM100 when the user did not explicitly set attention backends
- keep short uncached prompts on FlashInfer paged MLA, while routing long uncached prompts to the MHA/FA4 path instead of forcing the short-prompt paged MLA path
- keep FlashInfer paged MLA `q`/`q_rope` contiguous before calling the paged prefill wrapper
- unwrap hybrid/TBO attention backends before initializing MHA chunk metadata
- keep the native Mistral tokenizer BOS compatibility and FlashInfer TRT-LLM MoE defaults from the earlier PR commits

Root cause from the accuracy debug: this was not a generic FlashInfer kernel correctness bug. The native Mistral config sets YARN `apply_scale=false`, which SGLang maps to `apply_yarn_scaling=False`. The attention layer respected that flag, but `ModelConfig` still applied YARN mscale and produced an over-large MLA attention scale used by FlashInfer paged MLA. Fixing that scale restores full-set GSM8K/MMLU accuracy.

## Performance

Model: `mistralai/Mistral-Small-4-119B-2603-NVFP4`

Hardware: single NVIDIA B200, `CUDA_VISIBLE_DEVICES=2`

Workload: OpenAI completions, random prompts, 80 requests, max concurrency 80, `temperature=0`, `top_p=1`, `ignore_eos=true`. Before benchmark runs, GPU/process/memory/utilization snapshots were recorded; the measured runs below used only one B200.

| Framework | Candidate | Scenario | Req/s | Output tok/s | Mean TTFT s | Mean TPOT s | Success / Failed |
|---|---|---:|---:|---:|---:|---:|---:|
| SGLang | fixed default: FlashInfer prefill + TRT-LLM MLA decode + FlashInfer TRT-LLM MoE, `--max-running-requests 80 --cuda-graph-max-bs 80` | 1000/1000 | 6.5756 | 6455.5 | 0.598 | 0.01225 | 80 / 0 |
| vLLM latest | `vllm/vllm-openai:latest`, FlashInfer MLA + FlashInfer TRT-LLM MoE | 1000/1000 | 6.3922 | 6283.7 | 0.642 | 0.01207 | 80 / 0 |
| SGLang | fixed + long-prefill deployment: `--prefill-attention-backend fa4 --decode-attention-backend trtllm_mla --cuda-graph-max-bs 512` + FlashInfer TRT-LLM MoE | 8000/1000 | 3.9912 | 3536.0 | 3.071 | 0.02507 | 80 / 0 |
| vLLM latest | `vllm/vllm-openai:latest`, FlashInfer MLA + FlashInfer TRT-LLM MoE | 8000/1000 | 2.7458 | 2467.1 | 11.400 | 0.02291 | 80 / 0 |

Notes:

- The 1000/1000 regression in the previous PR description came from globally switching SGLang prefill to FA4; this revision restores the short-prompt fast path with FlashInfer paged MLA after fixing the attention scale.
- For 8000/1000, explicit FA4 prefill remains the fastest fair deployment observed in this campaign. The code also avoids sending long uncached prompts through the short-prompt FlashInfer paged MLA path.
- TensorRT-LLM latest (`nvcr.io/nvidia/tensorrt-llm/release:latest`) did not produce a comparable native Mistral/NVFP4 server in this campaign because the latest image rejected the model/tokenizer checkpoint format for this path.

## Accuracy

Same model, single B200. GSM8K and MMLU are full-set 5-shot runs through `/v1/completions`.

| Framework | Candidate | Dataset | Accuracy | Requests | Notes |
|---|---|---:|---:|---:|---|
| SGLang | fixed default: FlashInfer prefill + TRT-LLM MLA decode + FlashInfer TRT-LLM MoE | GSM8K full | 91.81% | 1,319 | invalid rate 0.00%; pre-fix SGLang was 82.94% |
| vLLM latest | FlashInfer MLA + FlashInfer TRT-LLM MoE | GSM8K full | 91.21% | 1,319 | invalid rate 0.00% |
| SGLang | fixed default: FlashInfer prefill + TRT-LLM MLA decode + FlashInfer TRT-LLM MoE | MMLU full | 83.54% | 14,042 | repeat run: 83.43%; pre-fix SGLang was 75.84% |
| vLLM latest | FlashInfer MLA + FlashInfer TRT-LLM MoE | MMLU full | 83.63% | 14,042 | 57 subjects |

## Validation

- `git diff --check`
- `python3 -m py_compile python/sglang/srt/configs/model_config.py python/sglang/srt/layers/attention/flashinfer_mla_backend.py python/sglang/srt/layers/attention/hybrid_attn_backend.py python/sglang/srt/model_executor/model_runner.py python/sglang/srt/models/deepseek_common/attention_backend_handler.py python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py python/sglang/srt/server_args.py test/registered/unit/configs/test_model_config_scaling.py test/registered/unit/models/test_mla_attention_backend_handler.py test/registered/unit/server_args/test_server_args.py`
- Remote B200 targeted pytest: `10 passed` for `test_model_config_scaling.py`, `test_mla_attention_backend_handler.py`, and `TestMistralNvfp4BackendDefaults`
- SGLang 1000/1000 and 8000/1000 benchmark runs completed on one B200 with the performance numbers above
- Full GSM8K and MMLU completed on one B200 with the accuracy numbers above























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26325876367](https://github.com/BBuf/sglang/actions/runs/26325876367)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #26326107522](https://github.com/BBuf/sglang/actions/runs/26326107522)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

