### PR TITLE
[codex] Optimize GDN prefill split on B200

### DIFF
--- a/python/sglang/jit_kernel/triton/gdn_fused_proj.py
+++ b/python/sglang/jit_kernel/triton/gdn_fused_proj.py
@@ -308,3 +308,93 @@ def fused_qkvzba_split_reshape_cat_contiguous(
         num_stages=3,
     )
     return mixed_qkv, z, b, a
+
+
+@triton.jit
+def fused_qkv_split_gdn_prefill_kernel(
+    q,
+    k,
+    v,
+    mixed_qkv,
+    NUM_Q_HEADS: tl.constexpr,
+    NUM_K_HEADS: tl.constexpr,
+    NUM_V_HEADS: tl.constexpr,
+    HEAD_Q: tl.constexpr,
+    HEAD_K: tl.constexpr,
+    HEAD_V: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_SIZE)
+
+    q_dim: tl.constexpr = NUM_Q_HEADS * HEAD_Q
+    k_dim: tl.constexpr = NUM_K_HEADS * HEAD_K
+    v_dim: tl.constexpr = NUM_V_HEADS * HEAD_V
+    qk_dim: tl.constexpr = q_dim + k_dim
+    qkv_dim: tl.constexpr = qk_dim + v_dim
+
+    mask = offsets < qkv_dim
+    values = tl.load(mixed_qkv + i_t * qkv_dim + offsets, mask=mask)
+
+    q_mask = offsets < q_dim
+    tl.store(q + i_t * q_dim + offsets, values, mask=q_mask)
+
+    k_offsets = offsets - q_dim
+    k_mask = (offsets >= q_dim) & (offsets < qk_dim)
+    tl.store(k + i_t * k_dim + k_offsets, values, mask=k_mask)
+
+    v_offsets = offsets - qk_dim
+    v_mask = (offsets >= qk_dim) & (offsets < qkv_dim)
+    tl.store(v + i_t * v_dim + v_offsets, values, mask=v_mask)
+
+
+def fused_qkv_split_gdn_prefill(
+    mixed_qkv: torch.Tensor,
+    num_q_heads: int,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_q: int,
+    head_k: int,
+    head_v: int,
+):
+    """Split packed post-conv GDN QKV into contiguous FLA prefill tensors.
+
+    `mixed_qkv` is laid out per token as `[all_q | all_k | all_v]`. The FLA
+    chunk kernels consume separate contiguous `[1, T, H, D]` tensors, so this
+    fused split replaces three independent `aten::copy_` kernels from the
+    generic FLA input guard.
+    """
+    seq_len = mixed_qkv.shape[0]
+    q = torch.empty(
+        (1, seq_len, num_q_heads, head_q),
+        dtype=mixed_qkv.dtype,
+        device=mixed_qkv.device,
+    )
+    k = torch.empty(
+        (1, seq_len, num_k_heads, head_k),
+        dtype=mixed_qkv.dtype,
+        device=mixed_qkv.device,
+    )
+    v = torch.empty(
+        (1, seq_len, num_v_heads, head_v),
+        dtype=mixed_qkv.dtype,
+        device=mixed_qkv.device,
+    )
+
+    qkv_dim = num_q_heads * head_q + num_k_heads * head_k + num_v_heads * head_v
+    fused_qkv_split_gdn_prefill_kernel[(seq_len,)](
+        q,
+        k,
+        v,
+        mixed_qkv,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        head_q,
+        head_k,
+        head_v,
+        BLOCK_SIZE=triton.next_power_of_2(qkv_dim),
+        num_warps=8,
+        num_stages=3,
+    )
+    return q, k, v

--- a/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
+++ b/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
 
+import os
 from typing import Optional, Tuple
 
 import torch
@@ -20,6 +21,9 @@ from sglang.srt.layers.attention.fla.utils import (
 
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8, 16]
 CHUNK_SIZE = 64
+GDN_CHUNK_H_BV = int(os.getenv("SGLANG_GDN_CHUNK_H_BV", "32"))
+GDN_CHUNK_H_NUM_WARPS = int(os.getenv("SGLANG_GDN_CHUNK_H_NUM_WARPS", "4"))
+GDN_CHUNK_H_NUM_STAGES = int(os.getenv("SGLANG_GDN_CHUNK_H_NUM_STAGES", "4"))
 
 
 @triton.autotune(
@@ -32,8 +36,16 @@ CHUNK_SIZE = 64
     # because cloning the cache pool for each benchmark exceeds available memory.
     # NT_BUCKET is kept in the autotune key for forward-compatibility (allows
     # future per-bucket configs once the kernel is refactored to write final
-    # state to a separate output buffer).
-    configs=[triton.Config({"BV": 32}, num_warps=4, num_stages=2)],
+    # state to a separate output buffer). The env knobs keep this single-config
+    # property while allowing model/hardware-local validation of the selected
+    # tile without corrupting the state pool through multi-config autotune.
+    configs=[
+        triton.Config(
+            {"BV": GDN_CHUNK_H_BV},
+            num_warps=GDN_CHUNK_H_NUM_WARPS,
+            num_stages=GDN_CHUNK_H_NUM_STAGES,
+        )
+    ],
     key=["H", "K", "V", "BT", "USE_GK", "NT_BUCKET"],
     **autotune_cache_kwargs,
 )

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -453,13 +453,9 @@ class GDNAttnBackend(MambaAttnBackendBase):
                 [layer.q_dim, layer.k_dim, layer.v_dim],
                 dim=-1,
             )
-            query = query.view(
-                1, actual_seq_len, layer.num_q_heads, layer.head_q_dim
-            )
+            query = query.view(1, actual_seq_len, layer.num_q_heads, layer.head_q_dim)
             key = key.view(1, actual_seq_len, layer.num_k_heads, layer.head_k_dim)
-            value = value.view(
-                1, actual_seq_len, layer.num_v_heads, layer.head_v_dim
-            )
+            value = value.view(1, actual_seq_len, layer.num_v_heads, layer.head_v_dim)
 
         if is_target_verify:
             core_attn_out = self.kernel_dispatcher.target_verify(

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -27,6 +27,11 @@ if not is_cpu():
     )
 
 if is_cuda():
+    from sglang.jit_kernel.triton.gdn_fused_proj import fused_qkv_split_gdn_prefill
+
+MAX_FUSED_QKV_SPLIT_DIM = 8192
+
+if is_cuda():
     from sglang.srt.layers.attention.mamba.causal_conv1d import (
         causal_conv1d_fn as causal_conv1d_fn_cuda,
     )
@@ -426,16 +431,35 @@ class GDNAttnBackend(MambaAttnBackendBase):
                 seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
             ).transpose(0, 1)[:seq_len]
 
-        query, key, value = torch.split(
-            mixed_qkv,
-            [layer.q_dim, layer.k_dim, layer.v_dim],
-            dim=-1,
-        )
-
-        actual_seq_len = query.shape[0]
-        query = query.view(1, actual_seq_len, layer.num_q_heads, layer.head_q_dim)
-        key = key.view(1, actual_seq_len, layer.num_k_heads, layer.head_k_dim)
-        value = value.view(1, actual_seq_len, layer.num_v_heads, layer.head_v_dim)
+        actual_seq_len = mixed_qkv.shape[0]
+        qkv_dim = layer.q_dim + layer.k_dim + layer.v_dim
+        if (
+            is_cuda()
+            and mixed_qkv.is_contiguous()
+            and qkv_dim <= MAX_FUSED_QKV_SPLIT_DIM
+        ):
+            query, key, value = fused_qkv_split_gdn_prefill(
+                mixed_qkv,
+                layer.num_q_heads,
+                layer.num_k_heads,
+                layer.num_v_heads,
+                layer.head_q_dim,
+                layer.head_k_dim,
+                layer.head_v_dim,
+            )
+        else:
+            query, key, value = torch.split(
+                mixed_qkv,
+                [layer.q_dim, layer.k_dim, layer.v_dim],
+                dim=-1,
+            )
+            query = query.view(
+                1, actual_seq_len, layer.num_q_heads, layer.head_q_dim
+            )
+            key = key.view(1, actual_seq_len, layer.num_k_heads, layer.head_k_dim)
+            value = value.view(
+                1, actual_seq_len, layer.num_v_heads, layer.head_v_dim
+            )
 
         if is_target_verify:
             core_attn_out = self.kernel_dispatcher.target_verify(


### PR DESCRIPTION
## Summary

This patch closes the Qwen3.6 GDN prefill kernel gaps observed on 1x NVIDIA B200:

- add a Triton `fused_qkv_split_gdn_prefill_kernel` to split post-conv GDN Q/K/V into contiguous FLA prefill tensors in one launch;
- route contiguous CUDA GDN prefill tensors through that fused split path with a guarded fallback to the previous `torch.split(...).view(...)` path;
- tune the single safe `chunk_gated_delta_rule_fwd_kernel_h_blockdim64` config to `BV=32`, `num_warps=4`, `num_stages=4`, while keeping env overrides for validation.

The chunk-h autotune remains single-config because this kernel updates the state pool in place; multi-config autotune can corrupt the state pool during benchmarking.

## Benchmark

Model: `Qwen/Qwen3.6-35B-A3B-FP8`  
Hardware: single NVIDIA B200, `CUDA_VISIBLE_DEVICES=1`  
Workload: default SOTA serving workload, 80 random prompts, `--disable-radix-cache` for the winning SGLang lane.

| Framework / candidate | Chat 1000/1000 out tok/s | Chat TTFT ms | Chat TPOT ms | Long 8000/1000 out tok/s | Long TTFT ms | Long TPOT ms |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| SGLang baseline best | 7205.38 | 858.08 | 10.20 | 4243.72 | 4014.37 | 14.55 |
| vLLM latest best | 6480.19 | 1975.60 | 10.33 | 3993.22 | 4275.92 | 15.35 |
| SGLang patched GDN fused split + w4/s4 | 7396.73 | 709.25 | 10.07 | 4353.39 | 3820.19 | 14.28 |
| TensorRT-LLM latest | N/A | N/A | N/A | N/A | N/A | N/A |

TensorRT-LLM latest could not serve this checkpoint because the bundled Transformers stack does not recognize `model_type=qwen3_5_moe`.

## Kernel Profile

| Row | Baseline SGLang | Patched SGLang | vLLM latest best |
| --- | ---: | ---: | ---: |
| `chunk_gated_delta_rule_fwd_kernel_h_blockdim64` | 24.21 ms / 90 = 269.00 us | 19.69 ms / 90 = 218.78 us | 34.25 ms / 150 = 228.34 us |
| FLA/GDN prep copy | 18.97 ms | removed; replaced by 3.33 ms fused split | no matching extra row |
| `fused_qkv_split_gdn_prefill_kernel` | N/A | 3.33 ms / 90 = 37.00 us | N/A |

## Accuracy

Full-dataset regression runs used the same model and 1x B200 setup. The eval command used `--chat-template-kwargs '{"enable_thinking": false}'`; MMLU used `--max-tokens 512`, and GSM8K used `--max-tokens 1024 --num-shots 5`.

| Variant | MMLU full | GSM8K full | Delta vs baseline |
| --- | ---: | ---: | ---: |
| Baseline SGLang | 0.436761 | 0.954338 | - |
| SGLang patched GDN fused split + w4/s4 | 0.437687 | 0.955860 | +0.000926 MMLU / +0.001522 GSM8K |

## Validation

- `python3 -m py_compile python/sglang/jit_kernel/triton/gdn_fused_proj.py python/sglang/srt/layers/attention/fla/chunk_delta_h.py python/sglang/srt/layers/attention/linear/gdn_backend.py`
- Real-model serving benchmark on `ion-b200`, single B200.
- Torch profiler comparison against the strongest vLLM latest-image candidate.
- Full MMLU and GSM8K regression runs for baseline and patched SGLang.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26325876313](https://github.com/BBuf/sglang/actions/runs/26325876313)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #26326107419](https://github.com/BBuf/sglang/actions/runs/26326107419)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->