### PR TITLE
[B300] Enable FlashInfer allreduce for Qwen3-VL MoE

### DIFF
--- a/docs_new/index.mdx
+++ b/docs_new/index.mdx
@@ -83,6 +83,61 @@ It is designed to deliver low-latency and high-throughput inference across a wid
     }}
   >
     <a
+      href="https://lmsys.org/blog/2026-06-04-nvidia-run-nemotron-3-ultra/"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid rgba(128, 128, 128, 0.3)",
+        borderRadius: "0.75rem",
+        overflow: "hidden",
+        textDecoration: "none",
+        color: "inherit",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: "16 / 9",
+          overflow: "hidden",
+          background: "rgba(128, 128, 128, 0.15)",
+        }}
+      >
+        <img
+          src="https://lmsys.org/images/blog/nemotron-3-ultra/image1.png"
+          alt="SGLang and Miles Add Day-0 Support for NVIDIA Nemotron 3 Ultra for Long-Running Autonomous Agents"
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            display: "block",
+          }}
+        />
+      </div>
+      <div style={{ padding: "0.9rem 1rem 1rem" }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            fontSize: "0.98rem",
+          }}
+        >
+          {"SGLang and Miles Add Day-0 Support for NVIDIA Nemotron 3 Ultra for Long-Running Autonomous Agents"}
+        </p>
+        <p
+          style={{
+            margin: "0.55rem 0 0",
+            fontSize: "0.85rem",
+            opacity: 0.75,
+          }}
+        >
+          {"June 4, 2026"}
+        </p>
+      </div>
+    </a>
+    <a
       href="https://lmsys.org/blog/2026-06-01-hetero-epd/"
       target="_blank"
       rel="noopener noreferrer"
@@ -354,61 +409,6 @@ It is designed to deliver low-latency and high-throughput inference across a wid
           }}
         >
           {"April 10, 2026"}
-        </p>
-      </div>
-    </a>
-    <a
-      href="https://lmsys.org/blog/2026-03-25-gtc2026/"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        display: "block",
-        border: "1px solid rgba(128, 128, 128, 0.3)",
-        borderRadius: "0.75rem",
-        overflow: "hidden",
-        textDecoration: "none",
-        color: "inherit",
-        height: "100%",
-      }}
-    >
-      <div
-        style={{
-          aspectRatio: "16 / 9",
-          overflow: "hidden",
-          background: "rgba(128, 128, 128, 0.15)",
-        }}
-      >
-        <img
-          src="https://lmsys.org/images/blog/gtc2026/happyhour-crowd.jpg"
-          alt="Highlights of SGLang at NVIDIA GTC 2026"
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-            display: "block",
-          }}
-        />
-      </div>
-      <div style={{ padding: "0.9rem 1rem 1rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontWeight: 600,
-            lineHeight: 1.35,
-            fontSize: "0.98rem",
-          }}
-        >
-          {"Highlights of SGLang at NVIDIA GTC 2026"}
-        </p>
-        <p
-          style={{
-            margin: "0.55rem 0 0",
-            fontSize: "0.85rem",
-            opacity: 0.75,
-          }}
-        >
-          {"March 31, 2026"}
         </p>
       </div>
     </a>

--- a/docs_new/index.mdx
+++ b/docs_new/index.mdx
@@ -83,6 +83,61 @@ It is designed to deliver low-latency and high-throughput inference across a wid
     }}
   >
     <a
+      href="https://lmsys.org/blog/2026-06-08-lmsys-phd-fellowship/"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid rgba(128, 128, 128, 0.3)",
+        borderRadius: "0.75rem",
+        overflow: "hidden",
+        textDecoration: "none",
+        color: "inherit",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: "16 / 9",
+          overflow: "hidden",
+          background: "rgba(128, 128, 128, 0.15)",
+        }}
+      >
+        <img
+          src="https://lmsys.org/images/blog/fellowship_apply/fellowship_program.png"
+          alt="Announcing the Recipient of the 2026 LMSYS PhD Fellowship"
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            display: "block",
+          }}
+        />
+      </div>
+      <div style={{ padding: "0.9rem 1rem 1rem" }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            fontSize: "0.98rem",
+          }}
+        >
+          {"Announcing the Recipient of the 2026 LMSYS PhD Fellowship"}
+        </p>
+        <p
+          style={{
+            margin: "0.55rem 0 0",
+            fontSize: "0.85rem",
+            opacity: 0.75,
+          }}
+        >
+          {"June 08, 2026"}
+        </p>
+      </div>
+    </a>
+    <a
       href="https://lmsys.org/blog/2026-06-04-nvidia-run-nemotron-3-ultra/"
       target="_blank"
       rel="noopener noreferrer"
@@ -354,61 +409,6 @@ It is designed to deliver low-latency and high-throughput inference across a wid
           }}
         >
           {"April 29, 2026"}
-        </p>
-      </div>
-    </a>
-    <a
-      href="https://lmsys.org/blog/2026-04-25-deepseek-v4/"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        display: "block",
-        border: "1px solid rgba(128, 128, 128, 0.3)",
-        borderRadius: "0.75rem",
-        overflow: "hidden",
-        textDecoration: "none",
-        color: "inherit",
-        height: "100%",
-      }}
-    >
-      <div
-        style={{
-          aspectRatio: "16 / 9",
-          overflow: "hidden",
-          background: "rgba(128, 128, 128, 0.15)",
-        }}
-      >
-        <img
-          src="https://lmsys.org/images/blog/deepseek_v4/benchmark_vs_oss.png"
-          alt="DeepSeek-V4 on Day 0: From Fast Inference to Verified RL with SGLang and Miles"
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-            display: "block",
-          }}
-        />
-      </div>
-      <div style={{ padding: "0.9rem 1rem 1rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontWeight: 600,
-            lineHeight: 1.35,
-            fontSize: "0.98rem",
-          }}
-        >
-          {"DeepSeek-V4 on Day 0: From Fast Inference to Verified RL with SGLang and Miles"}
-        </p>
-        <p
-          style={{
-            margin: "0.55rem 0 0",
-            fontSize: "0.85rem",
-            opacity: 0.75,
-          }}
-        >
-          {"April 25, 2026"}
         </p>
       </div>
     </a>

--- a/docs_new/index.mdx
+++ b/docs_new/index.mdx
@@ -83,6 +83,61 @@ It is designed to deliver low-latency and high-throughput inference across a wid
     }}
   >
     <a
+      href="https://lmsys.org/blog/2026-06-17-ling-2-6-tpu/"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid rgba(128, 128, 128, 0.3)",
+        borderRadius: "0.75rem",
+        overflow: "hidden",
+        textDecoration: "none",
+        color: "inherit",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: "16 / 9",
+          overflow: "hidden",
+          background: "rgba(128, 128, 128, 0.15)",
+        }}
+      >
+        <img
+          src="https://lmsys.org/images/blog/2026-06-17-ling-2-6-tpu/hero.png"
+          alt="Optimizing Ling-2.6-1T on TPU with SGLang-JAX: Hiding MoE Data Movement Behind Compute with One Pallas Kernel"
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            display: "block",
+          }}
+        />
+      </div>
+      <div style={{ padding: "0.9rem 1rem 1rem" }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            fontSize: "0.98rem",
+          }}
+        >
+          {"Optimizing Ling-2.6-1T on TPU with SGLang-JAX: Hiding MoE Data Movement Behind Compute with One Pallas Kernel"}
+        </p>
+        <p
+          style={{
+            margin: "0.55rem 0 0",
+            fontSize: "0.85rem",
+            opacity: 0.75,
+          }}
+        >
+          {"June 17, 2026"}
+        </p>
+      </div>
+    </a>
+    <a
       href="https://lmsys.org/blog/2026-06-15-next-generation-speculative-decoding-dflash-v2/"
       target="_blank"
       rel="noopener noreferrer"
@@ -354,61 +409,6 @@ It is designed to deliver low-latency and high-throughput inference across a wid
           }}
         >
           {"May 29, 2026"}
-        </p>
-      </div>
-    </a>
-    <a
-      href="https://lmsys.org/blog/2026-05-28-mori/"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        display: "block",
-        border: "1px solid rgba(128, 128, 128, 0.3)",
-        borderRadius: "0.75rem",
-        overflow: "hidden",
-        textDecoration: "none",
-        color: "inherit",
-        height: "100%",
-      }}
-    >
-      <div
-        style={{
-          aspectRatio: "16 / 9",
-          overflow: "hidden",
-          background: "rgba(128, 128, 128, 0.15)",
-        }}
-      >
-        <img
-          src="https://lmsys.org/images/blog/mori/tco1-new.png"
-          alt="Win on TCO: How AMD Instinct\u2122 MI355X Achieves Cost-Competitive Distributed Inference Through SGLang with MoRI"
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-            display: "block",
-          }}
-        />
-      </div>
-      <div style={{ padding: "0.9rem 1rem 1rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontWeight: 600,
-            lineHeight: 1.35,
-            fontSize: "0.98rem",
-          }}
-        >
-          {"Win on TCO: How AMD Instinct\u2122 MI355X Achieves Cost-Competitive Distributed Inference Through SGLang with MoRI"}
-        </p>
-        <p
-          style={{
-            margin: "0.55rem 0 0",
-            fontSize: "0.85rem",
-            opacity: 0.75,
-          }}
-        >
-          {"May 28, 2026"}
         </p>
       </div>
     </a>

--- a/docs_new/index.mdx
+++ b/docs_new/index.mdx
@@ -83,6 +83,61 @@ It is designed to deliver low-latency and high-throughput inference across a wid
     }}
   >
     <a
+      href="https://lmsys.org/blog/2026-06-01-hetero-epd/"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid rgba(128, 128, 128, 0.3)",
+        borderRadius: "0.75rem",
+        overflow: "hidden",
+        textDecoration: "none",
+        color: "inherit",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: "16 / 9",
+          overflow: "hidden",
+          background: "rgba(128, 128, 128, 0.15)",
+        }}
+      >
+        <img
+          src="https://lmsys.org/images/blog/hetero-epd/1.png"
+          alt="Heterogeneous CPU + GPU EPD Disaggregation to Boost VLM Serving"
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            display: "block",
+          }}
+        />
+      </div>
+      <div style={{ padding: "0.9rem 1rem 1rem" }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            fontSize: "0.98rem",
+          }}
+        >
+          {"Heterogeneous CPU + GPU EPD Disaggregation to Boost VLM Serving"}
+        </p>
+        <p
+          style={{
+            margin: "0.55rem 0 0",
+            fontSize: "0.85rem",
+            opacity: 0.75,
+          }}
+        >
+          {"May 29, 2026"}
+        </p>
+      </div>
+    </a>
+    <a
       href="https://lmsys.org/blog/2026-05-28-mori/"
       target="_blank"
       rel="noopener noreferrer"
@@ -354,61 +409,6 @@ It is designed to deliver low-latency and high-throughput inference across a wid
           }}
         >
           {"March 31, 2026"}
-        </p>
-      </div>
-    </a>
-    <a
-      href="https://lmsys.org/blog/2026-03-25-eep-partial-failure-tolerance/"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        display: "block",
-        border: "1px solid rgba(128, 128, 128, 0.3)",
-        borderRadius: "0.75rem",
-        overflow: "hidden",
-        textDecoration: "none",
-        color: "inherit",
-        height: "100%",
-      }}
-    >
-      <div
-        style={{
-          aspectRatio: "16 / 9",
-          overflow: "hidden",
-          background: "rgba(128, 128, 128, 0.15)",
-        }}
-      >
-        <img
-          src="https://lmsys.org/images/blog/eep-partial-failure-tolerance/figure.png"
-          alt="Elastic EP in SGLang: Achieving Partial Failure Tolerance for DeepSeek MoE Deployments"
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-            display: "block",
-          }}
-        />
-      </div>
-      <div style={{ padding: "0.9rem 1rem 1rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontWeight: 600,
-            lineHeight: 1.35,
-            fontSize: "0.98rem",
-          }}
-        >
-          {"Elastic EP in SGLang: Achieving Partial Failure Tolerance for DeepSeek MoE Deployments"}
-        </p>
-        <p
-          style={{
-            margin: "0.55rem 0 0",
-            fontSize: "0.85rem",
-            opacity: 0.75,
-          }}
-        >
-          {"March 25, 2026"}
         </p>
       </div>
     </a>

--- a/docs_new/index.mdx
+++ b/docs_new/index.mdx
@@ -83,6 +83,61 @@ It is designed to deliver low-latency and high-throughput inference across a wid
     }}
   >
     <a
+      href="https://lmsys.org/blog/2026-05-28-mori/"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid rgba(128, 128, 128, 0.3)",
+        borderRadius: "0.75rem",
+        overflow: "hidden",
+        textDecoration: "none",
+        color: "inherit",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: "16 / 9",
+          overflow: "hidden",
+          background: "rgba(128, 128, 128, 0.15)",
+        }}
+      >
+        <img
+          src="https://lmsys.org/images/blog/mori/tco1-new.png"
+          alt="Win on TCO: How AMD Instinct\u2122 MI355X Achieves Cost-Competitive Distributed Inference Through SGLang with MoRI"
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            display: "block",
+          }}
+        />
+      </div>
+      <div style={{ padding: "0.9rem 1rem 1rem" }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            fontSize: "0.98rem",
+          }}
+        >
+          {"Win on TCO: How AMD Instinct\u2122 MI355X Achieves Cost-Competitive Distributed Inference Through SGLang with MoRI"}
+        </p>
+        <p
+          style={{
+            margin: "0.55rem 0 0",
+            fontSize: "0.85rem",
+            opacity: 0.75,
+          }}
+        >
+          {"May 28, 2026"}
+        </p>
+      </div>
+    </a>
+    <a
       href="https://lmsys.org/blog/2026-04-29-p2p-update/"
       target="_blank"
       rel="noopener noreferrer"
@@ -354,61 +409,6 @@ It is designed to deliver low-latency and high-throughput inference across a wid
           }}
         >
           {"March 25, 2026"}
-        </p>
-      </div>
-    </a>
-    <a
-      href="https://lmsys.org/blog/2026-03-17-rocm-miles-rl-amd/"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        display: "block",
-        border: "1px solid rgba(128, 128, 128, 0.3)",
-        borderRadius: "0.75rem",
-        overflow: "hidden",
-        textDecoration: "none",
-        color: "inherit",
-        height: "100%",
-      }}
-    >
-      <div
-        style={{
-          aspectRatio: "16 / 9",
-          overflow: "hidden",
-          background: "rgba(128, 128, 128, 0.15)",
-        }}
-      >
-        <img
-          src="https://lmsys.org/images/blog/rocm_miles_rl/fig_1.png"
-          alt="ROCm Support for Miles: Large-Scale RL Post-Training on AMD Instinct\u2122 GPUs"
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-            display: "block",
-          }}
-        />
-      </div>
-      <div style={{ padding: "0.9rem 1rem 1rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontWeight: 600,
-            lineHeight: 1.35,
-            fontSize: "0.98rem",
-          }}
-        >
-          {"ROCm Support for Miles: Large-Scale RL Post-Training on AMD Instinct\u2122 GPUs"}
-        </p>
-        <p
-          style={{
-            margin: "0.55rem 0 0",
-            fontSize: "0.85rem",
-            opacity: 0.75,
-          }}
-        >
-          {"March 17, 2026"}
         </p>
       </div>
     </a>

--- a/docs_new/index.mdx
+++ b/docs_new/index.mdx
@@ -138,6 +138,61 @@ It is designed to deliver low-latency and high-throughput inference across a wid
       </div>
     </a>
     <a
+      href="https://lmsys.org/blog/2026-06-04-higgs-audio-v3-tts/"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid rgba(128, 128, 128, 0.3)",
+        borderRadius: "0.75rem",
+        overflow: "hidden",
+        textDecoration: "none",
+        color: "inherit",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: "16 / 9",
+          overflow: "hidden",
+          background: "rgba(128, 128, 128, 0.15)",
+        }}
+      >
+        <img
+          src="https://sgl-project.github.io/sglang-omni/_images/higgs-architecture.png"
+          alt="Higgs Audio v3 TTS on SGLang-Omni: Real-Time, Controllable Speech for Voice Agents"
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            display: "block",
+          }}
+        />
+      </div>
+      <div style={{ padding: "0.9rem 1rem 1rem" }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            fontSize: "0.98rem",
+          }}
+        >
+          {"Higgs Audio v3 TTS on SGLang-Omni: Real-Time, Controllable Speech for Voice Agents"}
+        </p>
+        <p
+          style={{
+            margin: "0.55rem 0 0",
+            fontSize: "0.85rem",
+            opacity: 0.75,
+          }}
+        >
+          {"June 4, 2026"}
+        </p>
+      </div>
+    </a>
+    <a
       href="https://lmsys.org/blog/2026-06-01-hetero-epd/"
       target="_blank"
       rel="noopener noreferrer"
@@ -354,61 +409,6 @@ It is designed to deliver low-latency and high-throughput inference across a wid
           }}
         >
           {"April 25, 2026"}
-        </p>
-      </div>
-    </a>
-    <a
-      href="https://lmsys.org/blog/2026-04-10-sglang-hisparse/"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        display: "block",
-        border: "1px solid rgba(128, 128, 128, 0.3)",
-        borderRadius: "0.75rem",
-        overflow: "hidden",
-        textDecoration: "none",
-        color: "inherit",
-        height: "100%",
-      }}
-    >
-      <div
-        style={{
-          aspectRatio: "16 / 9",
-          overflow: "hidden",
-          background: "rgba(128, 128, 128, 0.15)",
-        }}
-      >
-        <img
-          src="https://lmsys.org/images/blog/hisparse/hisparse_overview.png"
-          alt="HiSparse: Turbocharging Sparse Attention with Hierarchical Memory"
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-            display: "block",
-          }}
-        />
-      </div>
-      <div style={{ padding: "0.9rem 1rem 1rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontWeight: 600,
-            lineHeight: 1.35,
-            fontSize: "0.98rem",
-          }}
-        >
-          {"HiSparse: Turbocharging Sparse Attention with Hierarchical Memory"}
-        </p>
-        <p
-          style={{
-            margin: "0.55rem 0 0",
-            fontSize: "0.85rem",
-            opacity: 0.75,
-          }}
-        >
-          {"April 10, 2026"}
         </p>
       </div>
     </a>

--- a/docs_new/index.mdx
+++ b/docs_new/index.mdx
@@ -83,6 +83,61 @@ It is designed to deliver low-latency and high-throughput inference across a wid
     }}
   >
     <a
+      href="https://lmsys.org/blog/2026-06-17-moss-tts-local-v15/"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid rgba(128, 128, 128, 0.3)",
+        borderRadius: "0.75rem",
+        overflow: "hidden",
+        textDecoration: "none",
+        color: "inherit",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: "16 / 9",
+          overflow: "hidden",
+          background: "rgba(128, 128, 128, 0.15)",
+        }}
+      >
+        <img
+          src="https://raw.githubusercontent.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/main/sglang/sglang-omni/images/moss-local-transformer-arch.svg"
+          alt="MOSS-TTS Local Transformer v1.5 on SGLang-Omni: Serving Native-Streaming 48 kHz Speech"
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            display: "block",
+          }}
+        />
+      </div>
+      <div style={{ padding: "0.9rem 1rem 1rem" }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            fontSize: "0.98rem",
+          }}
+        >
+          {"MOSS-TTS Local Transformer v1.5 on SGLang-Omni: Serving Native-Streaming 48 kHz Speech"}
+        </p>
+        <p
+          style={{
+            margin: "0.55rem 0 0",
+            fontSize: "0.85rem",
+            opacity: 0.75,
+          }}
+        >
+          {"June 17, 2026"}
+        </p>
+      </div>
+    </a>
+    <a
       href="https://lmsys.org/blog/2026-06-17-ling-2-6-tpu/"
       target="_blank"
       rel="noopener noreferrer"
@@ -354,61 +409,6 @@ It is designed to deliver low-latency and high-throughput inference across a wid
           }}
         >
           {"June 4, 2026"}
-        </p>
-      </div>
-    </a>
-    <a
-      href="https://lmsys.org/blog/2026-06-01-hetero-epd/"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        display: "block",
-        border: "1px solid rgba(128, 128, 128, 0.3)",
-        borderRadius: "0.75rem",
-        overflow: "hidden",
-        textDecoration: "none",
-        color: "inherit",
-        height: "100%",
-      }}
-    >
-      <div
-        style={{
-          aspectRatio: "16 / 9",
-          overflow: "hidden",
-          background: "rgba(128, 128, 128, 0.15)",
-        }}
-      >
-        <img
-          src="https://lmsys.org/images/blog/hetero-epd/1.png"
-          alt="Heterogeneous CPU + GPU EPD Disaggregation to Boost VLM Serving"
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-            display: "block",
-          }}
-        />
-      </div>
-      <div style={{ padding: "0.9rem 1rem 1rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontWeight: 600,
-            lineHeight: 1.35,
-            fontSize: "0.98rem",
-          }}
-        >
-          {"Heterogeneous CPU + GPU EPD Disaggregation to Boost VLM Serving"}
-        </p>
-        <p
-          style={{
-            margin: "0.55rem 0 0",
-            fontSize: "0.85rem",
-            opacity: 0.75,
-          }}
-        >
-          {"May 29, 2026"}
         </p>
       </div>
     </a>

--- a/docs_new/index.mdx
+++ b/docs_new/index.mdx
@@ -83,6 +83,61 @@ It is designed to deliver low-latency and high-throughput inference across a wid
     }}
   >
     <a
+      href="https://lmsys.org/blog/2026-06-15-next-generation-speculative-decoding-dflash-v2/"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid rgba(128, 128, 128, 0.3)",
+        borderRadius: "0.75rem",
+        overflow: "hidden",
+        textDecoration: "none",
+        color: "inherit",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: "16 / 9",
+          overflow: "hidden",
+          background: "rgba(128, 128, 128, 0.15)",
+        }}
+      >
+        <img
+          src="https://lmsys.org/images/blog/dflash-v2/dflash-arch-diagram.webp"
+          alt="The next generation of speculative decoding: DFlash and Spec V2"
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            display: "block",
+          }}
+        />
+      </div>
+      <div style={{ padding: "0.9rem 1rem 1rem" }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            fontSize: "0.98rem",
+          }}
+        >
+          {"The next generation of speculative decoding: DFlash and Spec V2"}
+        </p>
+        <p
+          style={{
+            margin: "0.55rem 0 0",
+            fontSize: "0.85rem",
+            opacity: 0.75,
+          }}
+        >
+          {"June 15, 2026"}
+        </p>
+      </div>
+    </a>
+    <a
       href="https://lmsys.org/blog/2026-06-08-lmsys-phd-fellowship/"
       target="_blank"
       rel="noopener noreferrer"
@@ -354,61 +409,6 @@ It is designed to deliver low-latency and high-throughput inference across a wid
           }}
         >
           {"May 28, 2026"}
-        </p>
-      </div>
-    </a>
-    <a
-      href="https://lmsys.org/blog/2026-04-29-p2p-update/"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        display: "block",
-        border: "1px solid rgba(128, 128, 128, 0.3)",
-        borderRadius: "0.75rem",
-        overflow: "hidden",
-        textDecoration: "none",
-        color: "inherit",
-        height: "100%",
-      }}
-    >
-      <div
-        style={{
-          aspectRatio: "16 / 9",
-          overflow: "hidden",
-          background: "rgba(128, 128, 128, 0.15)",
-        }}
-      >
-        <img
-          src="https://lmsys.org/images/blog/p2p-update/p2p-overview.png"
-          alt="Updating 1T parameters in seconds \u2014 P2P weight transfer in Large Scale Distributed RL"
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-            display: "block",
-          }}
-        />
-      </div>
-      <div style={{ padding: "0.9rem 1rem 1rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontWeight: 600,
-            lineHeight: 1.35,
-            fontSize: "0.98rem",
-          }}
-        >
-          {"Updating 1T parameters in seconds \u2014 P2P weight transfer in Large Scale Distributed RL"}
-        </p>
-        <p
-          style={{
-            margin: "0.55rem 0 0",
-            fontSize: "0.85rem",
-            opacity: 0.75,
-          }}
-        >
-          {"April 29, 2026"}
         </p>
       </div>
     </a>

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2515,7 +2515,7 @@ class ServerArgs:
 
         # TRTLLM AllReduce Fusion supports SM90/100, enable it by default
         # for models with explicit support (DeepseekV3, GptOss, Glm4Moe,
-        # MistralLarge3, Qwen3/Qwen3Next/Qwen3.5 MoE families)
+        # MistralLarge3, Qwen3/Qwen3-VL/Qwen3Next/Qwen3.5 MoE families)
         # TODO: currently, it is only supported in the single node scenario. https://github.com/flashinfer-ai/flashinfer/issues/2006
 
         if (
@@ -2530,6 +2530,7 @@ class ServerArgs:
                 "Glm4MoeLiteForCausalLM",
                 "MistralLarge3ForCausalLM",
                 "Qwen3MoeForCausalLM",
+                "Qwen3VLMoeForConditionalGeneration",
                 "Qwen3NextForCausalLM",
                 "KimiK25ForConditionalGeneration",
                 "Qwen3_5MoeForConditionalGeneration",


### PR DESCRIPTION
## Summary

This PR enables FlashInfer allreduce fusion by default for Qwen3-VL MoE on the same existing guarded path used by other supported MoE models:

- add `Qwen3VLMoeForConditionalGeneration` to the SM90/SM10X auto-enable allowlist
- keep the existing guards unchanged: TP > 1, single node, no DP attention, no MoE A2A backend
- no FlashInfer JIT/AOT workaround is included in this PR

Qwen3-VL MoE reuses the Qwen3 MoE decoder/layer-communicator path, and the optimization already works when explicitly enabled with `--enable-flashinfer-allreduce-fusion`. This PR makes that optimized path the default under the existing safety conditions.

## Environment note

During B300 validation, the container had a FlashInfer package mismatch:

| Package | Version |
| --- | --- |
| `flashinfer-python` | `0.6.12` |
| `flashinfer-cubin` | `0.6.12` |
| `flashinfer-jit-cache` | `0.6.11.post1+cu130` |

That mismatch made FlashInfer 0.6.12 Python pass `weight_bias` to a stale 0.6.11 AOT `trtllm_mnnvl_allreduce_fusion` binary, causing a 16-arg vs 15-arg ABI error. The benchmark used a test-environment workaround to load the compatible 0.6.12 JIT cache. That workaround is intentionally not part of this PR.

## Benchmark

Hardware and workload:

- single-node 8x NVIDIA B300 SXM6 AC
- FP8 checkpoint: `Qwen/Qwen3-VL-235B-A22B-Instruct-FP8`
- random workload, 80 prompts each
- `chat`: 1000 input / 1000 output
- `summarization`: 8000 input / 1000 output
- request rate 4, max concurrency 8
- SLA: p50 TTFT <= 1500 ms, p50 TPOT <= 30 ms, success rate >= 0.99

Effect of enabling FlashInfer allreduce fusion:

| Candidate | Chat req/s | Summ req/s | Geomean req/s | Notes |
| --- | ---: | ---: | ---: | --- |
| SGLang before enabling | 0.9976 | 0.8937 | 0.9442 | same 8x B300 budget |
| SGLang with FlashInfer AR fusion | 1.0385 | 0.9570 | 0.9969 | selected run |
| SGLang with FlashInfer AR fusion repeat | 1.0257 | 0.9574 | 0.9900 | repeat run |

Improvement over the SGLang pre-enable baseline:

| Run | Chat | Summarization | Geomean |
| --- | ---: | ---: | ---: |
| Selected | +4.1% | +7.1% | +5.6% |
| Repeat | +2.8% | +7.1% | +4.9% |

Framework comparison under the same workload/SLA:

| Candidate | Chat req/s | Chat output tok/s | Chat p50 TTFT | Chat p50 TPOT | Summ req/s | Summ output tok/s | Summ p50 TTFT | Summ p50 TPOT |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| SGLang with FlashInfer AR fusion | 1.0385 | 497.37 | 107.57 ms | 14.55 ms | 0.9570 | 457.39 | 150.83 ms | 15.79 ms |
| SGLang repeat | 1.0257 | 491.22 | 153.31 ms | 14.71 ms | 0.9574 | 457.58 | 141.67 ms | 15.77 ms |
| vLLM best | 1.0305 | 493.54 | 85.17 ms | 14.78 ms | 0.9649 | 461.14 | 140.94 ms | 15.75 ms |
| TensorRT-LLM best | 0.9676 | 463.41 | 90.76 ms | 15.61 ms | 0.8946 | 427.54 | 148.70 ms | 16.86 ms |

## Accuracy / correctness report

Full accuracy was validated with the same SGLang serving configuration used for the selected benchmark run, with FlashInfer allreduce fusion enabled. This PR only changes default enablement policy, but the full evals below verify the optimized path used by the benchmark.

| Check | Configuration | Examples | Score | Std | Evidence |
| --- | --- | ---: | ---: | ---: | --- |
| MMLU full | SGLang + FlashInfer AR fusion, `--max-tokens 1024`, temperature 0 | 14042 | 0.874519 | 0.331263 | `accuracy/selected_mixedchunk_full_accuracy/run_20260620_092945/results/mmlu_full.json` |
| GSM8K full | SGLang + FlashInfer AR fusion, 5-shot, `--max-tokens 512`, temperature 0 | 1314 | 0.957382 | 0.201994 | `accuracy/selected_mixedchunk_gsm8k_full/run_20260620_100009/results/gsm8k_full.json` |
| VLM smoke | OpenAI-compatible image request with a 1x1 red image | 1 | returned `Red` | n/a | HTTP 200 `/v1/chat/completions` smoke |

MMLU category breakdown:

| Category | Score |
| --- | ---: |
| STEM | 0.901590 |
| Social sciences | 0.916802 |
| Humanities | 0.816366 |
| Other | 0.893584 |

## Validation

- `python3 -m compileall -q python/sglang/srt/server_args.py python/sglang/srt/layers/flashinfer_comm_fusion.py`
- remote PR diff checked after force-push: only `python/sglang/srt/server_args.py` changes
- fixed fair benchmark against SGLang/vLLM/TensorRT-LLM
- full MMLU and GSM8K evals through the selected SGLang serving command

NCU was not collected because this PR only changes the default enablement policy and does not edit CUDA/Triton kernels.
