### PR TITLE
Add K3 fused KDA TP16 TP32 support

### DIFF
--- a/python/sglang/kernels/jit/csrc/attention/kda_fused_decode.cuh
+++ b/python/sglang/kernels/jit/csrc/attention/kda_fused_decode.cuh
@@ -388,7 +388,7 @@ template <
     int kTmaStages = kNumChunks,
     bool kUsePDL = false>
 // Shapes below use K3's per-TP-rank sizing (linear_attn_config: num_heads=96 over
-// TP=8 -> H=HV=12 local heads; head_dim=128 -> kDimK=kDimV=128; kSeg = H*128 = 1536;
+// TP={8,16,32} -> H=HV={12,6,3} local heads; head_dim=128 -> kDimK=kDimV=128; kSeg = H*128;
 // short_conv_kernel_size=4 -> kKernelWidth=4, kConvStateWidth=3). B is the live
 // (post-padding, under kUseStaticDecodeLayout) decode batch size; slots is the
 // recurrent-state / conv-cache pool capacity, addressed by ssm_state_indices, not B.
@@ -419,8 +419,8 @@ __global__ __launch_bounds__(kThreads, 2) void kda_decode_fusion_many_heads_kern
                                 // state_slot_stride
     __nv_bfloat16* __restrict__ out,  // [B, hv_count*128] fused-decode output, row i_n, col i_hv*128 + v
     int B,                            // live decode batch size (token count for this launch)
-    int H,                            // local key/query heads on this TP rank (12 for K3)
-    int HV,                           // local value heads on this TP rank (12 for K3, H==HV since KDA is MHA not GQA)
+    int H,                            // local key/query heads on this TP rank
+    int HV,                           // local value heads on this TP rank (H==HV since KDA is MHA not GQA)
     float lower_bound,                // linear_attn_config.gate_lower_bound (-5.0 for K3) when kUseLowerBound
     float scale,                      // query scale applied after L2-normalization
     float onorm_eps,                  // onorm RMSNorm epsilon
@@ -881,18 +881,18 @@ __global__ __launch_bounds__(kThreads, 2) void kda_decode_fusion_many_heads_kern
 }
 
 // K3 decode configuration of the many-heads kernel: onorm fused, static
-// H = HV = 12 layout with a (B, HV) grid, onorm params preloaded, next state
+// H = HV in {3, 6, 12} layout with a (B, HV) grid, onorm params preloaded, next state
 // chunk prefetched, active onorm reduction, conv cache updated in place,
 // beta sigmoid in-kernel. Both forget-gate variants are compiled (softplus
 // and lower-bounded sigmoid) and selected at launch from the model config.
 // kUseTmaLoad/kTmaStages select the 1D-TMA state-staging path in place of the
 // cp.async fallback used for a misaligned recurrent-state slot stride.
-template <bool kUseLowerBound, bool kUsePDL, bool kUseTmaLoad = false, int kTmaStages = kNumChunks>
+template <int kFixedHeads, bool kUseLowerBound, bool kUsePDL, bool kUseTmaLoad = false, int kTmaStages = kNumChunks>
 constexpr auto kda_fused_decode_k3_kernel = kda_decode_fusion_many_heads_kernel<
     /*kApplyOnorm=*/true,
     /*kUseStaticDecodeLayout=*/true,
-    /*kFixedHeads=*/12,
-    /*kFixedValueHeads=*/12,
+    /*kFixedHeads=*/kFixedHeads,
+    /*kFixedValueHeads=*/kFixedHeads,
     /*kUseHeadGrid=*/true,
     /*kAccumulateOnormSumsq=*/false,
     /*kUseActiveQkReduction=*/false,
@@ -908,6 +908,20 @@ constexpr auto kda_fused_decode_k3_kernel = kda_decode_fusion_many_heads_kernel<
     kUseTmaLoad,
     kTmaStages,
     kUsePDL>;
+
+template <int kFixedHeads, bool kUsePDL>
+auto select_kda_fused_decode_k3_kernel(bool use_lower_bound, int tma_stages) {
+  if (tma_stages == 3) {
+    return use_lower_bound ? kda_fused_decode_k3_kernel<kFixedHeads, true, kUsePDL, true, 3>
+                           : kda_fused_decode_k3_kernel<kFixedHeads, false, kUsePDL, true, 3>;
+  }
+  if (tma_stages == 4) {
+    return use_lower_bound ? kda_fused_decode_k3_kernel<kFixedHeads, true, kUsePDL, true, 4>
+                           : kda_fused_decode_k3_kernel<kFixedHeads, false, kUsePDL, true, 4>;
+  }
+  return use_lower_bound ? kda_fused_decode_k3_kernel<kFixedHeads, true, kUsePDL>
+                         : kda_fused_decode_k3_kernel<kFixedHeads, false, kUsePDL>;
+}
 
 template <bool kUsePDL>
 struct KdaFusedDecodeKernel {
@@ -933,8 +947,9 @@ struct KdaFusedDecodeKernel {
       bool use_lower_bound) {
     using namespace host;
 
-    constexpr int64_t kH = 12;
-    constexpr int64_t kSeg = kH * 128;  // 1536: q, k and v segment width
+    const int64_t kH = A_log.shape()[0];
+    RuntimeCheck(kH == 3 || kH == 6 || kH == 12, "KDA fused decode supports local head counts 3, 6, or 12, got ", kH);
+    const int64_t kSeg = kH * 128;  // q, k and v segment width
 
     auto B_ = SymbolicSize{"batch"};
     auto Slots_ = SymbolicSize{"pool_slots"};
@@ -981,8 +996,6 @@ struct KdaFusedDecodeKernel {
     // pools. Threaded into every ssm-state read/write; int64 avoids the
     // envelope-pitch overflow.
     const int64_t state_slot_stride = state.stride(0);
-    auto kernel =
-        use_lower_bound ? kda_fused_decode_k3_kernel<true, kUsePDL> : kda_fused_decode_k3_kernel<false, kUsePDL>;
     int tma_stages = 0;
     // TMA 1D-bulk needs the per-slot source address (state + slot*stride) 16B
     // aligned for every slot. state.data_ptr() is torch-aligned and each chunk
@@ -998,15 +1011,10 @@ struct KdaFusedDecodeKernel {
       // 48KB 3-stage variant (one sync for the single stage reuse) benches
       // fastest.
       tma_stages = B * static_cast<int>(kH) >= 512 ? 3 : 4;
-      if (tma_stages == 3) {
-        kernel = use_lower_bound ? kda_fused_decode_k3_kernel<true, kUsePDL, true, 3>
-                                 : kda_fused_decode_k3_kernel<false, kUsePDL, true, 3>;
-      } else {
-        tma_stages = 4;
-        kernel = use_lower_bound ? kda_fused_decode_k3_kernel<true, kUsePDL, true, 4>
-                                 : kda_fused_decode_k3_kernel<false, kUsePDL, true, 4>;
-      }
     }
+    auto kernel = kH == 3 ? select_kda_fused_decode_k3_kernel<3, kUsePDL>(use_lower_bound, tma_stages)
+                          : (kH == 6 ? select_kda_fused_decode_k3_kernel<6, kUsePDL>(use_lower_bound, tma_stages)
+                                     : select_kda_fused_decode_k3_kernel<12, kUsePDL>(use_lower_bound, tma_stages));
     const int smem_stages = tma_stages == 0 ? 2 : tma_stages;
     const size_t smem_bytes = static_cast<size_t>(smem_stages) * kChunkV * kDimK * sizeof(float);
     host::RuntimeDeviceCheck(

--- a/python/sglang/kernels/ops/attention/kda_fused_decode.py
+++ b/python/sglang/kernels/ops/attention/kda_fused_decode.py
@@ -10,7 +10,9 @@ and the sigmoid-gated output RMSNorm.
 Kernel body vendored from the NVIDIA x Moonshot Kimi K3 optimization package
 (see csrc/attention/kda_fused_decode.cuh for provenance and the list of
 integration patches). Specialized for the K3 KDA decode regime:
-H = HV = 12, K = V = 128, kernel width 4, no lower bound, T = 1 per request.
+K = V = 128, kernel width 4, no lower bound, T = 1 per request.
+The JIT currently instantiates local head counts H = HV in {12, 6, 3}
+(TP8, TP16, and TP32).
 
 The model must hand off the output-norm gate (attempt-and-verify stash on the
 attention layer, see kimi_k3.py), and a covered() check gates supported inputs.
@@ -33,9 +35,7 @@ from sglang.kernels.jit.utils import (
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
 
-_H = 12  # q/k/v heads per rank (TP8) — the compiled static layout
-_SEG = _H * 128  # 1536: per-segment width of q, k and v
-_CONV_DIM = 3 * _SEG
+_SUPPORTED_HEADS = {3, 6, 12}
 _CONV_STATE_W = 3  # kernel width 4 -> 3 cached tokens
 
 
@@ -60,25 +60,30 @@ def covered(
     cache_indices: torch.Tensor,
     onorm_g: torch.Tensor,
 ) -> bool:
-    """The kernel is compiled for the K3 KDA decode regime: 12 heads of 128,
-    packed [T, 4608] qkv rows, transposed [slots, 3, 4608] conv pool, fp32
-    [slots, 12, 128, 128] ssm pool (inner-contiguous, any slot pitch — the
+    """The kernel is compiled for the K3 KDA decode regime: H heads of 128,
+    packed [T, 3*H*128] qkv rows, transposed [slots, 3, 3*H*128] conv pool, fp32
+    [slots, H, 128, 128] ssm pool (inner-contiguous, any slot pitch — the
     kernel reads the real slot stride), one token per request."""
-    if mixed_qkv.ndim != 2 or mixed_qkv.shape[-1] != _CONV_DIM:
+    if ssm_states.ndim < 4:
         return False
-    HV, V, K = ssm_states.shape[-3:]
+    H, V, K = ssm_states.shape[-3:]
+    if H not in _SUPPORTED_HEADS:
+        return False
+    seg = H * 128
+    conv_dim = 3 * seg
+    if mixed_qkv.ndim != 2 or mixed_qkv.shape[-1] != conv_dim:
+        return False
     return (
-        HV == _H
-        and V == 128
+        V == 128
         and K == 128
         and a.ndim == 2
-        and a.shape[-1] == _SEG
+        and a.shape[-1] == seg
         and b.ndim == 2
-        and b.shape[-1] == _H
+        and b.shape[-1] == H
         and onorm_g.ndim == 2
-        and onorm_g.shape[-1] == _SEG
+        and onorm_g.shape[-1] == seg
         and conv_states.ndim == 3
-        and conv_states.shape[-2:] == (_CONV_STATE_W, _CONV_DIM)
+        and conv_states.shape[-2:] == (_CONV_STATE_W, conv_dim)
         and mixed_qkv.dtype == torch.bfloat16
         and a.dtype == torch.bfloat16
         and b.dtype == torch.bfloat16
@@ -129,7 +134,9 @@ def kda_fused_decode(
     attention output [1, B, HV, V] (the packed-decode output layout).
     Caller must have checked covered()."""
     B = mixed_qkv.shape[0]
-    out = torch.empty((B, _SEG), dtype=torch.bfloat16, device=mixed_qkv.device)
+    H = ssm_states.shape[-3]
+    seg = H * 128
+    out = torch.empty((B, seg), dtype=torch.bfloat16, device=mixed_qkv.device)
     _jit_kda_fused_decode_module().run(
         mixed_qkv,
         a,
@@ -145,7 +152,7 @@ def kda_fused_decode(
         onorm_weight,
         # Pass the pool view as-is (already [slots, HV, V, K]); the kernel
         # binding reads its real slot stride via state.stride(0). A
-        # .view(-1, _H, 128, 128) here would break on envelope-strided pools
+        # .view(-1, H, 128, 128) here would break on envelope-strided pools
         # (unified / page-major) — the reshape can't fold a non-dense slot
         # pitch and would raise / silently copy.
         ssm_states,
@@ -156,4 +163,4 @@ def kda_fused_decode(
         float(lower_bound) if lower_bound is not None else 0.0,
         lower_bound is not None,
     )
-    return out.view(1, B, _H, 128)
+    return out.view(1, B, H, 128)

--- a/test/registered/kernels/ops/attention/test_kda_fused_decode.py
+++ b/test/registered/kernels/ops/attention/test_kda_fused_decode.py
@@ -1,0 +1,209 @@
+"""Kimi-K3 fused KDA decode must match the existing unfused decode chain.
+
+The fused kernel replaces:
+
+    causal_conv1d_update -> kda_packed_decode -> sigmoid-gated RMSNorm
+
+This file covers the local head layouts used by Kimi-K3 TP8/TP16/TP32:
+H = 12/6/3. The H=6 and H=3 cases are the branches added by the fixed-head
+dispatch in ``kda_fused_decode.cuh``.
+"""
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention import kda_fused_decode
+from sglang.kernels.ops.attention.fla.fused_norm_gate import rms_norm_gated
+from sglang.kernels.ops.attention.fla.fused_recurrent import (
+    fused_recurrent_kda_packed_decode,
+)
+from sglang.kernels.ops.mamba.causal_conv1d_triton import causal_conv1d_update
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=8, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+_HEAD_DIM = 128
+_CONV_STATE_W = 3
+_SLOTS = 8
+_BATCH = 4
+
+
+def _randn(shape, dtype, generator, scale=1.0):
+    return (torch.randn(shape, device="cuda", generator=generator) * scale).to(dtype)
+
+
+def _make_case(heads: int, seed: int):
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    seg = heads * _HEAD_DIM
+    conv_dim = 3 * seg
+
+    # Keep magnitudes moderate so fp32 state updates stay in a stable range.
+    mixed_qkv = _randn((_BATCH, conv_dim), torch.bfloat16, generator, scale=0.2)
+    a = _randn((_BATCH, seg), torch.bfloat16, generator, scale=0.2)
+    b = _randn((_BATCH, heads), torch.bfloat16, generator, scale=0.2)
+    onorm_g = _randn((_BATCH, seg), torch.bfloat16, generator, scale=0.2)
+
+    conv_states = _randn(
+        (_SLOTS, _CONV_STATE_W, conv_dim), torch.bfloat16, generator, scale=0.2
+    )
+    ssm_states = _randn(
+        (_SLOTS, heads, _HEAD_DIM, _HEAD_DIM), torch.float32, generator, scale=0.02
+    )
+    cache_indices = torch.arange(_BATCH, device="cuda", dtype=torch.int32)
+
+    conv_weights = _randn((conv_dim, 4), torch.float32, generator, scale=0.1)
+    conv_bias = _randn((conv_dim,), torch.float32, generator, scale=0.05)
+    a_log = _randn((heads,), torch.float32, generator, scale=0.1)
+    dt_bias = _randn((seg,), torch.float32, generator, scale=0.1)
+    onorm_weight = _randn((_HEAD_DIM,), torch.float32, generator, scale=0.1) + 1.0
+
+    return (
+        mixed_qkv,
+        a,
+        b,
+        onorm_g,
+        conv_states,
+        ssm_states,
+        cache_indices,
+        conv_weights,
+        conv_bias,
+        a_log,
+        dt_bias,
+        onorm_weight,
+    )
+
+
+def _run_unfused_reference(
+    mixed_qkv,
+    a,
+    b,
+    onorm_g,
+    conv_states,
+    ssm_states,
+    cache_indices,
+    conv_weights,
+    conv_bias,
+    a_log,
+    dt_bias,
+    onorm_weight,
+):
+    heads = ssm_states.shape[-3]
+    qkv = causal_conv1d_update(
+        mixed_qkv,
+        conv_states.transpose(-1, -2),
+        conv_weights,
+        conv_bias,
+        activation="silu",
+        conv_state_indices=cache_indices,
+    )
+    out = torch.empty(
+        (_BATCH, 1, heads, _HEAD_DIM), dtype=torch.bfloat16, device="cuda"
+    )
+    out, _ = fused_recurrent_kda_packed_decode(
+        qkv,
+        a,
+        b,
+        a_log,
+        dt_bias,
+        _HEAD_DIM**-0.5,
+        ssm_states,
+        out,
+        cache_indices,
+        use_qk_l2norm_in_kernel=True,
+    )
+    ref = rms_norm_gated(
+        out,
+        onorm_g.view(1, _BATCH, heads, _HEAD_DIM),
+        onorm_weight,
+        None,
+        activation="sigmoid",
+        eps=1e-6,
+    )
+    return ref.transpose(0, 1).contiguous()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize(
+    "heads,tp_size",
+    [
+        pytest.param(3, 32, id="tp32_h3"),
+        pytest.param(6, 16, id="tp16_h6"),
+        pytest.param(12, 8, id="tp8_h12"),
+    ],
+)
+def test_kda_fused_decode_matches_unfused_chain(heads: int, tp_size: int):
+    (
+        mixed_qkv,
+        a,
+        b,
+        onorm_g,
+        conv_states,
+        ssm_states,
+        cache_indices,
+        conv_weights,
+        conv_bias,
+        a_log,
+        dt_bias,
+        onorm_weight,
+    ) = _make_case(heads=heads, seed=20260731 + tp_size)
+
+    conv_ref = conv_states.clone()
+    conv_fused = conv_states.clone()
+    state_ref = ssm_states.clone()
+    state_fused = ssm_states.clone()
+
+    w_q_t, w_k_t, w_v_t = [
+        weight.t().contiguous()
+        for weight in conv_weights.split(heads * _HEAD_DIM, dim=0)
+    ]
+
+    assert kda_fused_decode.covered(
+        mixed_qkv,
+        a,
+        b,
+        conv_fused,
+        state_fused,
+        cache_indices,
+        onorm_g,
+    )
+
+    ref = _run_unfused_reference(
+        mixed_qkv.clone(),
+        a,
+        b,
+        onorm_g,
+        conv_ref,
+        state_ref,
+        cache_indices,
+        conv_weights,
+        conv_bias,
+        a_log,
+        dt_bias,
+        onorm_weight,
+    )
+    fused = kda_fused_decode.kda_fused_decode(
+        mixed_qkv.clone(),
+        a,
+        b,
+        conv_fused,
+        w_q_t,
+        w_k_t,
+        w_v_t,
+        conv_bias,
+        a_log,
+        dt_bias,
+        onorm_g,
+        onorm_weight,
+        state_fused,
+        cache_indices,
+        scale=_HEAD_DIM**-0.5,
+        onorm_eps=1e-6,
+    )
+    torch.cuda.synchronize()
+
+    # JIT log breadcrumb for PR/CI evidence that the fused fixed-head branch ran.
+    print(f"K3 fused KDA decode test used fused path: TP{tp_size}, H={heads}")
+
+    torch.testing.assert_close(fused, ref, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(state_fused, state_ref, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(conv_fused, conv_ref, rtol=0, atol=0)

--- a/test/registered/unit/mem_cache/test_kda_fused_decode_strided_state.py
+++ b/test/registered/unit/mem_cache/test_kda_fused_decode_strided_state.py
@@ -1,0 +1,230 @@
+"""NV KDA fused-decode kernel gate + slot addressing vs envelope-strided SSM
+pools (CPU).
+
+Derived property under test: the fully-fused KDA decode kernel
+(``kda_fused_decode``) addresses the ssm/temporal state pool by the slot pitch
+the pool actually reports (``ssm_states.stride(0)``), NOT the dense ``HV*V*K``
+pitch. Under ``--enable-unified-memory`` / ``--enable-page-major-kv-layout`` the
+per-layer temporal view is envelope-strided: one slot pitches across ALL layers
+(56,171,520 B on K3), so a hardcoded ``slot*HV*V*K`` offset mis-addresses every
+slot > 0 (the exact chunk_delta_h hardcoded-pitch bug pattern, GSM8K 0.17).
+
+Two things are pinned here (both CPU-checkable without the CUDA kernel):
+
+  1. ``covered()`` ACCEPTS the envelope-strided view. Pre-fix the gate did
+     ``ssm_states.view(-1, HV, V, K).is_contiguous()``, which is False on a
+     non-dense slot pitch, so decode silently dropped to the slower unfused
+     chain. Reverting to that ``.view(...)`` gate turns test (1) red. The gate
+     still REJECTS a view whose inner ``[HV, V, K]`` is non-contiguous (the
+     one contract the float4 state loads rely on).
+
+  2. The kernel's reconstructed slot-addressing formula
+     ``base + slot*stride(0) + i_hv*V*K + v*K + k`` resolves to the exact same
+     storage element as torch's native ``ssm_states[slot, i_hv, v, k]`` on the
+     strided pool, while the pre-fix dense-pitch formula
+     ``base + slot*(HV*V*K) + ...`` resolves ELSEWHERE for every slot > 0.
+     Hardcoding the dense pitch back into the ``.cuh`` turns test (2) red.
+
+Runs on CPU: only the Python gate and the (dtype/stride-only) addressing
+arithmetic execute — no CUDA kernel is launched.
+
+    python -m pytest test/registered/unit/mem_cache/test_kda_fused_decode_strided_state.py -v
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+import unittest
+
+import torch
+
+from sglang.kernels.ops.attention.kda_fused_decode import (
+    _CONV_STATE_W,
+    covered,
+)
+from sglang.srt.mem_cache.layout.page_major import (
+    build_page_major_mamba_views,
+    mamba_entry_bytes,
+)
+
+_DEV = "cpu"
+
+# The kernel is compiled for the K3 KDA decode regime; covered() enforces these
+# supported local head counts. Multi-layer + several slots so the envelope slot
+# pitch differs from the dense H*V*K pitch.
+_KDA_HEADS = (3, 6, 12)
+_V = 128
+_K = 128
+_LAYERS = 3
+_LAYER_UNDER_TEST = 1
+_SLOTS = 6
+_CONV_SHAPES = ((3, 8),)  # tiny bf16 conv region interleaves the temporal region
+_CONV_DTYPE = torch.bfloat16
+_TEMPORAL_DTYPE = torch.float32
+
+
+def _seg(heads: int) -> int:
+    return heads * _V
+
+
+def _conv_dim(heads: int) -> int:
+    return 3 * _seg(heads)
+
+
+def _make_strided_temporal_view(heads: int):
+    """Envelope-strided temporal (SSM) view as UnifiedMambaPool / the
+    page-major MambaPool serve it to the KDA backend: shape
+    ``(num_layers, max_slots, H, V, K)`` with the slot pitch spanning ALL
+    layers' state, not H*V*K."""
+    entry = mamba_entry_bytes(
+        layer_num=_LAYERS,
+        conv_state_shapes=_CONV_SHAPES,
+        conv_dtype=_CONV_DTYPE,
+        temporal_state_shape=(heads, _V, _K),
+        temporal_dtype=_TEMPORAL_DTYPE,
+    )
+    raw = torch.zeros(_SLOTS * entry, dtype=torch.uint8, device=_DEV)
+    _conv_views, temporal = build_page_major_mamba_views(
+        raw,
+        layer_num=_LAYERS,
+        conv_state_shapes=_CONV_SHAPES,
+        conv_dtype=_CONV_DTYPE,
+        temporal_state_shape=(heads, _V, _K),
+        temporal_dtype=_TEMPORAL_DTYPE,
+        max_slots=_SLOTS,
+    )
+    return raw, temporal
+
+
+def _make_covered_side_args(batch: int, heads: int):
+    """The non-ssm covered() arguments, in the exact K3 shapes/dtypes so the
+    gate turns solely on the ssm_states view under test."""
+    bf16 = torch.bfloat16
+    seg = _seg(heads)
+    conv_dim = _conv_dim(heads)
+    mixed_qkv = torch.zeros((batch, conv_dim), dtype=bf16, device=_DEV)
+    a = torch.zeros((batch, seg), dtype=bf16, device=_DEV)
+    b = torch.zeros((batch, heads), dtype=bf16, device=_DEV)
+    onorm_g = torch.zeros((batch, seg), dtype=bf16, device=_DEV)
+    conv_states = torch.zeros(
+        (_SLOTS, _CONV_STATE_W, conv_dim), dtype=bf16, device=_DEV
+    )
+    cache_indices = torch.zeros((batch,), dtype=torch.int32, device=_DEV)
+    return mixed_qkv, a, b, conv_states, onorm_g, cache_indices
+
+
+def _addressing_samples(heads: int):
+    return [
+        (0, 0, 0, 0),
+        (5, heads - 1, 127, 127),
+        (3, heads // 2, 64, 100),
+        (1, 0, 0, 1),
+        (2, min(heads - 1, 2), 3, 7),
+    ]
+
+
+class TestKdaFusedDecodeStridedState(unittest.TestCase):
+    def test_covered_accepts_envelope_strided_and_rejects_noncontiguous_inner(self):
+        for heads in _KDA_HEADS:
+            with self.subTest(kda_heads=heads):
+                _raw, temporal = _make_strided_temporal_view(heads)
+                ssm = temporal[_LAYER_UNDER_TEST]  # what mamba2_layer_cache serves
+
+                # Precondition: the pool really is envelope-strided (else the
+                # property below would be vacuous — a dense pool passes the old
+                # gate too).
+                self.assertNotEqual(
+                    ssm.stride(0),
+                    heads * _V * _K,
+                    "test setup no longer produces a strided pool",
+                )
+                # Inner [H, V, K] IS contiguous — the contract the kernel's
+                # float4 state loads rely on and all covered() must still require.
+                self.assertEqual(
+                    (ssm.stride(-1), ssm.stride(-2), ssm.stride(-3)),
+                    (1, _K, _V * _K),
+                )
+
+                (
+                    mixed_qkv,
+                    a,
+                    b,
+                    conv_states,
+                    onorm_g,
+                    cache_indices,
+                ) = _make_covered_side_args(batch=2, heads=heads)
+
+                # (1) Accept the envelope-strided view — pre-fix
+                # .view(...).is_contiguous() would reject this and drop decode
+                # to the unfused chain.
+                self.assertTrue(
+                    covered(mixed_qkv, a, b, conv_states, ssm, cache_indices, onorm_g),
+                    "covered() rejected the envelope-strided ssm pool (fused decode "
+                    "would silently fall back to the unfused chain)",
+                )
+
+                # Still reject a view whose inner dims are NOT contiguous: the
+                # kernel cannot float4-load a transposed [.., V, K] state.
+                ssm_bad = ssm.transpose(-1, -2)  # stride(-1) == K, not 1
+                self.assertFalse(
+                    covered(
+                        mixed_qkv,
+                        a,
+                        b,
+                        conv_states,
+                        ssm_bad,
+                        cache_indices,
+                        onorm_g,
+                    ),
+                    "covered() must reject a non-inner-contiguous ssm view",
+                )
+
+    def test_slot_formula_resolves_correct_element_and_dense_pitch_misaddresses(self):
+        for heads in _KDA_HEADS:
+            with self.subTest(kda_heads=heads):
+                raw, temporal = _make_strided_temporal_view(heads)
+                ssm = temporal[_LAYER_UNDER_TEST]
+
+                # Distinct value per storage element so an offset that lands
+                # elsewhere reads a provably different value.
+                raw_fp32 = raw.view(torch.float32)
+                raw_fp32.copy_(torch.arange(raw_fp32.numel(), dtype=torch.float32))
+
+                base = ssm.storage_offset()
+                # == state.stride(0) the wrapper passes the kernel.
+                slot_stride = ssm.stride(0)
+                dense_pitch = heads * _V * _K  # the pre-fix hardcoded slot pitch
+
+                for slot, i_hv, v, k in _addressing_samples(heads):
+                    intra = (
+                        i_hv * (_V * _K) + v * _K + k
+                    )  # kernel's hardcoded intra-slot offset
+                    kernel_off = base + slot * slot_stride + intra
+
+                    # (2a) The kernel formula names exactly the element torch
+                    # indexing names — proves slot*stride(0) + intra addresses
+                    # the intended slot.
+                    self.assertEqual(
+                        raw_fp32[kernel_off].item(),
+                        ssm[slot, i_hv, v, k].item(),
+                        f"kernel slot formula mis-addressed "
+                        f"(slot={slot}, i_hv={i_hv}, heads={heads})",
+                    )
+
+                    # (2b) The pre-fix dense-pitch formula lands on a DIFFERENT
+                    # element (a different layer's envelope region) for every
+                    # slot > 0.
+                    dense_off = base + slot * dense_pitch + intra
+                    if slot > 0:
+                        self.assertNotEqual(
+                            raw_fp32[dense_off].item(),
+                            ssm[slot, i_hv, v, k].item(),
+                            f"dense-pitch formula happened to match at "
+                            f"slot={slot}, heads={heads}; the fix would not "
+                            "be load-bearing",
+                        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Summary

This PR extends the Kimi-K3 fused KDA decode fast path to support additional tensor-parallel layouts.

Previously, the fused KDA decode kernel only accepted the TP8 layout, where each rank owns 12 local KDA heads. With larger TP sizes, such as TP16 and TP32, Kimi-K3 uses fewer local heads per rank, so the fused path was disabled with messages like:

```text
K3 fused KDA decode disabled: unexpected conv/A_log/dt_bias layout
```

This PR adds support for:

- TP8: 12 local heads per rank
- TP16: 6 local heads per rank
- TP32: 3 local heads per rank

## Changes

- Generalized the Python fused KDA decode wrapper to infer the local head count from `ssm_states`.
- Added supported local-head layouts `{3, 6, 12}`.
- Updated the C++ JIT wrapper to dispatch to static kernel specializations for `kFixedHeads = 3, 6, 12`.
- Relaxed the Kimi-K3 fused decode preparation check so TP16 and TP32 layouts can enable the fused path.

The kernel body itself is still per-head: each CUDA block processes one `(batch row, local value head)`, and the recurrent math remains fixed at `K=V=128`. The local head count only affects grid shape, segment width, and per-head offsets.

## Accuracy Tests

test case:
```
python3 -m pytest test/registered/kernels/ops/attention/test_kda_fused_decode.py -v -s                                                    

test/registered/kernels/ops/attention/test_kda_fused_decode.py::test_kda_fused_decode_matches_unfused_chain[tp32_h3] K3 fused KDA decode test used fused path: TP32, H=3
PASSED
test/registered/kernels/ops/attention/test_kda_fused_decode.py::test_kda_fused_decode_matches_unfused_chain[tp16_h6] K3 fused KDA decode test used fused path: TP16, H=6
PASSED
test/registered/kernels/ops/attention/test_kda_fused_decode.py::test_kda_fused_decode_matches_unfused_chain[tp8_h12] K3 fused KDA decode test used fused path: TP8, H=12
PASSED

python3 -m pytest test/registered/unit/mem_cache/test_kda_fused_decode_strided_state.py -v
                                                    
test/registered/unit/mem_cache/test_kda_fused_decode_strided_state.py::TestKdaFusedDecodeStridedState::test_covered_accepts_envelope_strided_and_rejects_noncontiguous_inner 
test/registered/unit/mem_cache/test_kda_fused_decode_strided_state.py::TestKdaFusedDecodeStridedState::test_covered_accepts_envelope_strided_and_rejects_noncontiguous_inner PASSED [ 50%]
test/registered/unit/mem_cache/test_kda_fused_decode_strided_state.py::TestKdaFusedDecodeStridedState::test_slot_formula_resolves_correct_element_and_dense_pitch_misaddresses 
test/registered/unit/mem_cache/test_kda_fused_decode_strided_state.py::TestKdaFusedDecodeStridedState::test_slot_formula_resolves_correct_element_and_dense_pitch_misaddresses PASSED [100%]
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
PR | Hardward | input | output | chunked-prefill-size | QPS | max_concurrency | num promot | TPOT(ms) | decode throughput
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
Before | H20 | 3500 | 1500 | 8192 | 4 | 64 | 256 | 73.49 | 757.84
After | H20 | 3500 | 1500 | 8192 | 4 | 64 | 256 | 64.26 | 854.66


<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30613975296](https://github.com/BBuf/sglang/actions/runs/30613975296)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30613975009](https://github.com/BBuf/sglang/actions/runs/30613975009)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->